### PR TITLE
Add Phase 1 chaos action framework and internal GraphQL stress action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@
 # Local development / test artifacts
 /vendor/
 /.phpunit.cache/
+/.worktrees/

--- a/Action/CacheFlush.php
+++ b/Action/CacheFlush.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Action;
+
+use Magento\Framework\App\Cache\Manager;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use Throwable;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CacheFlush implements ChaosActionInterface
+{
+    public function __construct(private Manager $cacheManager)
+    {
+    }
+
+    public function getCode(): string
+    {
+        return 'cache_flush';
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
+    {
+        $output->writeln('Flushing cache types...');
+
+        $details = [];
+        $hasFailure = false;
+
+        foreach (array_keys($this->cacheManager->getAvailableTypes()) as $typeCode) {
+            try {
+                $this->cacheManager->clean([$typeCode]);
+                $message = sprintf('Flushed: %s', $typeCode);
+                $output->writeln($message);
+                $details[] = $message;
+            } catch (Throwable $exception) {
+                $message = sprintf('Failed: %s (%s)', $typeCode, $exception->getMessage());
+                $output->writeln($message);
+                $details[] = $message;
+                $hasFailure = true;
+            }
+        }
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            $hasFailure ? 'Cache flush completed with failures' : 'Flushed all cache types successfully',
+            $details,
+            !$hasFailure
+        );
+    }
+}

--- a/Action/GraphQlInternalPipelineStress.php
+++ b/Action/GraphQlInternalPipelineStress.php
@@ -5,7 +5,6 @@ namespace ShaunMcManus\ChaosDonkey\Action;
 
 use Magento\Framework\App\FrontControllerInterface;
 use Magento\Framework\App\Request\HttpFactory;
-use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
 use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
 use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use Throwable;
@@ -21,7 +20,6 @@ class GraphQlInternalPipelineStress implements ChaosActionInterface
     public function __construct(
         private FrontControllerInterface $frontController,
         private HttpFactory $requestFactory,
-        private HttpResponseFactory $responseFactory,
         ?array $payloads = null
     ) {
         $this->payloads = $payloads ?? [
@@ -44,14 +42,13 @@ class GraphQlInternalPipelineStress implements ChaosActionInterface
 
         foreach ($this->payloads as $index => $query) {
             $request = $this->requestFactory->create();
-            $response = $this->responseFactory->create();
 
             $request->setPathInfo('/graphql');
             $request->setMethod('POST');
             $request->setContent((string) json_encode(['query' => $query]));
 
             try {
-                $this->frontController->dispatch($request);
+                $response = $this->frontController->dispatch($request);
 
                 $statusCode = $response->getHttpResponseCode();
                 $body = $response->getBody();

--- a/Action/GraphQlInternalPipelineStress.php
+++ b/Action/GraphQlInternalPipelineStress.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Action;
+
+use Magento\Framework\App\FrontControllerInterface;
+use Magento\Framework\App\Request\HttpFactory;
+use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use Throwable;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GraphQlInternalPipelineStress implements ChaosActionInterface
+{
+    /**
+     * @var list<string>
+     */
+    private array $payloads;
+
+    public function __construct(
+        private FrontControllerInterface $frontController,
+        private HttpFactory $requestFactory,
+        private HttpResponseFactory $responseFactory,
+        ?array $payloads = null
+    ) {
+        $this->payloads = $payloads ?? [
+            '{ products(search: "shirt", pageSize: 3) { items { sku name } } }',
+            '{ categories(filters: { parent_id: { eq: "2" } }) { items { id name } } }',
+        ];
+    }
+
+    public function getCode(): string
+    {
+        return 'graphql_pipeline_stress';
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
+    {
+        $output->writeln('Running internal GraphQL pipeline stress...');
+
+        $details = [];
+        $hasFailure = false;
+
+        foreach ($this->payloads as $index => $query) {
+            $request = $this->requestFactory->create();
+            $response = $this->responseFactory->create();
+
+            $request->setPathInfo('/graphql');
+            $request->setMethod('POST');
+            $request->setContent((string) json_encode(['query' => $query]));
+
+            try {
+                $this->frontController->dispatch($request);
+
+                $statusCode = $response->getHttpResponseCode();
+                $body = $response->getBody();
+
+                if ($statusCode >= 400 || str_contains($body, '"errors"')) {
+                    $message = sprintf('Failed: payload %d returned status %d', $index + 1, $statusCode);
+                    $hasFailure = true;
+                } else {
+                    $message = sprintf('OK: payload %d dispatched internally', $index + 1);
+                }
+
+                $output->writeln($message);
+                $details[] = $message;
+            } catch (Throwable $exception) {
+                $message = sprintf('Failed: payload %d (%s)', $index + 1, $exception->getMessage());
+                $output->writeln($message);
+                $details[] = $message;
+                $hasFailure = true;
+            }
+        }
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            $hasFailure
+                ? 'GraphQL pipeline stress completed with failures'
+                : 'GraphQL internal pipeline stress completed successfully',
+            $details,
+            !$hasFailure
+        );
+    }
+}

--- a/Action/ReindexAll.php
+++ b/Action/ReindexAll.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 namespace ShaunMcManus\ChaosDonkey\Action;
 
 use Magento\Indexer\Model\Indexer\CollectionFactory;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use Throwable;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReindexAll
+class ReindexAll implements ChaosActionInterface
 {
     private CollectionFactory $collectionFactory;
 
@@ -16,9 +18,16 @@ class ReindexAll
         $this->collectionFactory = $collectionFactory;
     }
 
-    public function execute(OutputInterface $output): void
+    public function getCode(): string
+    {
+        return 'reindex_all';
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
     {
         $output->writeln('Reindexing all indexers...');
+        $details = [];
+        $hasFailure = false;
 
         foreach ($this->collectionFactory->create() as $indexer) {
             $indexerId = (string) $indexer->getId();
@@ -28,11 +37,20 @@ class ReindexAll
             try {
                 $indexer->reindexAll();
                 $output->writeln(sprintf('Done: %s', $indexerId));
+                $details[] = sprintf('Done: %s', $indexerId);
             } catch (Throwable $exception) {
-                $output->writeln(
-                    sprintf('Failed: %s (%s)', $indexerId, $exception->getMessage())
-                );
+                $message = sprintf('Failed: %s (%s)', $indexerId, $exception->getMessage());
+                $output->writeln($message);
+                $details[] = $message;
+                $hasFailure = true;
             }
         }
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            $hasFailure ? 'Reindex completed with failures' : 'Reindexed all indexers successfully',
+            $details,
+            !$hasFailure
+        );
     }
 }

--- a/Api/ChaosActionInterface.php
+++ b/Api/ChaosActionInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Api;
+
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ChaosActionInterface
+{
+    public function getCode(): string;
+
+    public function execute(OutputInterface $output): ChaosActionResult;
+}

--- a/Console/Command/ChaosDonkeyKick.php
+++ b/Console/Command/ChaosDonkeyKick.php
@@ -3,9 +3,10 @@ declare(strict_types = 1);
 
 namespace ShaunMcManus\ChaosDonkey\Console\Command;
 
-use ShaunMcManus\ChaosDonkey\Action\ReindexAll;
+use ShaunMcManus\ChaosDonkey\Model\ActionPool;
 use ShaunMcManus\ChaosDonkey\Model\Config;
 use ShaunMcManus\ChaosDonkey\Model\KickRoller;
+use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
 use ShaunMcManus\ChaosDonkey\Model\StateWriter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,19 +15,22 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ChaosDonkeyKick extends Command
 {
     private Config $config;
-    private ReindexAll $reindexAll;
+    private ActionPool $actionPool;
+    private RollOutcomeResolver $resolver;
     private StateWriter $stateWriter;
     private KickRoller $kickRoller;
 
     public function __construct(
         Config $config,
-        ReindexAll $reindexAll,
+        ActionPool $actionPool,
+        RollOutcomeResolver $resolver,
         StateWriter $stateWriter,
         KickRoller $kickRoller
     ) {
         parent::__construct();
         $this->config = $config;
-        $this->reindexAll = $reindexAll;
+        $this->actionPool = $actionPool;
+        $this->resolver = $resolver;
         $this->stateWriter = $stateWriter;
         $this->kickRoller = $kickRoller;
     }
@@ -54,21 +58,21 @@ class ChaosDonkeyKick extends Command
         }
 
         $kick = $this->kickRoller->rollD20();
+        $outcome = $this->resolver->resolve($kick);
         $output->writeln('ChaosDonkeyKick kicks your Magento. You rolled a ' . $kick);
 
-        $outcome = match ($kick) {
-            1 => 'critical_failure',
-            2 => 'reindex_all',
-            20 => 'critical_success',
-            default => 'napping',
-        };
-
-        match ($kick) {
-            1 => $output->writeln('Critical Failure! Better check all of your donkeys.'),
-            2 => $this->reindexAll->execute($output),
-            20 => $output->writeln('Critical Success! Yee Haw the donkeys are loose!'),
-            default => $output->writeln('The donkeys are napping'),
-        };
+        $action = $this->actionPool->get($outcome);
+        if ($action !== null) {
+            $result = $action->execute($output);
+            $output->writeln($result->getSummary());
+        } else {
+            match ($outcome) {
+                'critical_failure' => $output->writeln('Critical Failure! Better check all of your donkeys.'),
+                'critical_success' => $output->writeln('Critical Success! Yee Haw the donkeys are loose!'),
+                'napping' => $output->writeln('The donkeys are napping'),
+                default => $output->writeln('Unknown chaos outcome. The donkeys stare suspiciously.'),
+            };
+        }
 
         $this->stateWriter->saveLastRun((new \DateTimeImmutable())->format(DATE_ATOM));
         $this->stateWriter->saveLastKick($kick);

--- a/Model/ActionPool.php
+++ b/Model/ActionPool.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model;
+
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+
+class ActionPool
+{
+    /**
+     * @param array<string, ChaosActionInterface> $actions
+     */
+    public function __construct(private array $actions)
+    {
+    }
+
+    public function get(string $code): ?ChaosActionInterface
+    {
+        return $this->actions[$code] ?? null;
+    }
+}

--- a/Model/ChaosActionResult.php
+++ b/Model/ChaosActionResult.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model;
+
+class ChaosActionResult
+{
+    /**
+     * @param list<string> $details
+     */
+    public function __construct(
+        private string $outcomeCode,
+        private string $summary,
+        private array $details = [],
+        private bool $success = true
+    ) {
+    }
+
+    public function getOutcomeCode(): string
+    {
+        return $this->outcomeCode;
+    }
+
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->success;
+    }
+}

--- a/Model/RollOutcomeResolver.php
+++ b/Model/RollOutcomeResolver.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model;
+
+class RollOutcomeResolver
+{
+    public function resolve(int $roll): string
+    {
+        return match ($roll) {
+            1 => 'critical_failure',
+            2 => 'reindex_all',
+            3 => 'cache_flush',
+            4 => 'graphql_pipeline_stress',
+            20 => 'critical_success',
+            default => 'napping',
+        };
+    }
+}

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@ Rolls a D20 and executes a mapped outcome.
   - `admin/chaos_donkey/last_outcome` (outcome key)
 
 Current outcome mapping:
-- `1`: critical failure message
-- `2`: reindex all indexers
-- `20`: critical success message
-- default: napping message
+- `1`: critical failure message (`critical_failure`)
+- `2`: reindex all indexers (`reindex_all`)
+- `3`: flush cache types (`cache_flush`)
+- `4`: run internal GraphQL pipeline stress (`graphql_pipeline_stress`)
+- `20`: critical success message (`critical_success`)
+- default: napping message (`napping`)
+
+For action outcomes, `chaosdonkey:kick` resolves an action code and executes a DI-wired action service from the action pool.
 
 ### `bin/magento chaosdonkey:status`
 Prints real module status values from config/state:
@@ -31,6 +35,21 @@ On roll `2`, `ReindexAll` iterates all Magento indexers and:
 - prints per-indexer progress
 - runs `reindexAll()` on each indexer
 - catches per-indexer exceptions and continues reindexing the rest
+
+## Cache Flush Behavior
+
+On roll `3`, `CacheFlush`:
+- enumerates available cache types
+- flushes each type individually
+- continues on per-type failures and reports a summary
+
+## Internal GraphQL Pipeline Stress
+
+On roll `4`, `GraphQlInternalPipelineStress`:
+- creates synthetic in-process requests targeting `/graphql`
+- dispatches those requests through Magento's internal HTTP pipeline (no external web HTTP calls)
+- uses default built-in GraphQL payloads in Phase 1
+- aggregates per-payload success/failure details
 
 ## Local Unit Tests
 

--- a/Test/Stubs/Magento/Framework/App/Cache/Manager.php
+++ b/Test/Stubs/Magento/Framework/App/Cache/Manager.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Cache;
+
+class Manager
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAvailableTypes(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param list<string> $types
+     */
+    public function clean(array $types): void
+    {
+    }
+}

--- a/Test/Stubs/Magento/Framework/App/FrontControllerInterface.php
+++ b/Test/Stubs/Magento/Framework/App/FrontControllerInterface.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Magento\Framework\App;
 
 use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Response\Http as HttpResponse;
 
 interface FrontControllerInterface
 {
-    public function dispatch(Http $request): void;
+    public function dispatch(Http $request): HttpResponse;
 }

--- a/Test/Stubs/Magento/Framework/App/FrontControllerInterface.php
+++ b/Test/Stubs/Magento/Framework/App/FrontControllerInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App;
+
+use Magento\Framework\App\Request\Http;
+
+interface FrontControllerInterface
+{
+    public function dispatch(Http $request): void;
+}

--- a/Test/Stubs/Magento/Framework/App/Request/Http.php
+++ b/Test/Stubs/Magento/Framework/App/Request/Http.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Request;
+
+class Http
+{
+    public function setPathInfo(string $pathInfo): void
+    {
+    }
+
+    public function setMethod(string $method): void
+    {
+    }
+
+    public function setContent(string $content): void
+    {
+    }
+}

--- a/Test/Stubs/Magento/Framework/App/Request/HttpFactory.php
+++ b/Test/Stubs/Magento/Framework/App/Request/HttpFactory.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Request;
+
+class HttpFactory
+{
+    public function create(): Http
+    {
+        return new Http();
+    }
+}

--- a/Test/Stubs/Magento/Framework/App/Response/Http.php
+++ b/Test/Stubs/Magento/Framework/App/Response/Http.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Response;
+
+class Http
+{
+    public function getHttpResponseCode(): int
+    {
+        return 200;
+    }
+
+    public function getBody(): string
+    {
+        return '{}';
+    }
+}

--- a/Test/Stubs/Magento/Framework/App/Response/HttpFactory.php
+++ b/Test/Stubs/Magento/Framework/App/Response/HttpFactory.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Response;
+
+class HttpFactory
+{
+    public function create(): Http
+    {
+        return new Http();
+    }
+}

--- a/Test/Unit/Action/CacheFlushTest.php
+++ b/Test/Unit/Action/CacheFlushTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Action;
+
+use Magento\Framework\App\Cache\Manager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShaunMcManus\ChaosDonkey\Action\CacheFlush;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CacheFlushTest extends TestCase
+{
+    private Manager&MockObject $cacheManager;
+
+    protected function setUp(): void
+    {
+        $this->cacheManager = $this->createMock(Manager::class);
+    }
+
+    public function testItFlushesAllCacheTypesSuccessfully(): void
+    {
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('getAvailableTypes')
+            ->willReturn(['config' => 1, 'full_page' => 1]);
+
+        $this->cacheManager
+            ->expects(self::exactly(2))
+            ->method('clean')
+            ->willReturnCallback(static function (array $types): void {
+                static $calls = 0;
+                $calls++;
+
+                if ($calls === 1) {
+                    self::assertSame(['config'], $types);
+                }
+
+                if ($calls === 2) {
+                    self::assertSame(['full_page'], $types);
+                }
+            });
+
+        $action = new CacheFlush($this->cacheManager);
+        $output = new BufferedOutput();
+
+        $result = $action->execute($output);
+
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertTrue($result->isSuccess());
+        self::assertSame('cache_flush', $result->getOutcomeCode());
+        self::assertSame('Flushed all cache types successfully', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
+    }
+
+    public function testItContinuesWhenOneCacheTypeFails(): void
+    {
+        $this->cacheManager
+            ->expects(self::once())
+            ->method('getAvailableTypes')
+            ->willReturn(['config' => 1, 'full_page' => 1]);
+
+        $invocation = 0;
+        $this->cacheManager
+            ->expects(self::exactly(2))
+            ->method('clean')
+            ->willReturnCallback(static function (array $types) use (&$invocation): void {
+                $invocation++;
+
+                if ($invocation === 2) {
+                    throw new RuntimeException('flush failed');
+                }
+            });
+
+        $action = new CacheFlush($this->cacheManager);
+        $output = new BufferedOutput();
+
+        $result = $action->execute($output);
+
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertFalse($result->isSuccess());
+        self::assertSame('cache_flush', $result->getOutcomeCode());
+        self::assertSame('Cache flush completed with failures', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
+        self::assertStringContainsString('Failed: full_page', implode("\n", $result->getDetails()));
+    }
+}

--- a/Test/Unit/Action/GraphQlInternalPipelineStressTest.php
+++ b/Test/Unit/Action/GraphQlInternalPipelineStressTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Action;
+
+use Magento\Framework\App\FrontControllerInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Request\HttpFactory;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShaunMcManus\ChaosDonkey\Action\GraphQlInternalPipelineStress;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class GraphQlInternalPipelineStressTest extends TestCase
+{
+    private FrontControllerInterface&MockObject $frontController;
+    private HttpFactory&MockObject $requestFactory;
+    private HttpResponseFactory&MockObject $responseFactory;
+
+    protected function setUp(): void
+    {
+        $this->frontController = $this->createMock(FrontControllerInterface::class);
+        $this->requestFactory = $this->createMock(HttpFactory::class);
+        $this->responseFactory = $this->createMock(HttpResponseFactory::class);
+    }
+
+    public function testItDispatchesMultipleInternalGraphQlRequests(): void
+    {
+        $requestOne = $this->createMock(Http::class);
+        $requestOne->expects(self::once())->method('setPathInfo')->with('/graphql');
+        $requestOne->expects(self::once())->method('setMethod')->with('POST');
+        $requestOne->expects(self::once())->method('setContent')->with(self::isString());
+
+        $requestTwo = $this->createMock(Http::class);
+        $requestTwo->expects(self::once())->method('setPathInfo')->with('/graphql');
+        $requestTwo->expects(self::once())->method('setMethod')->with('POST');
+        $requestTwo->expects(self::once())->method('setContent')->with(self::isString());
+
+        $responseOne = $this->createStub(HttpResponse::class);
+        $responseOne->method('getHttpResponseCode')->willReturn(200);
+        $responseOne->method('getBody')->willReturn('{"data":{}}');
+
+        $responseTwo = $this->createStub(HttpResponse::class);
+        $responseTwo->method('getHttpResponseCode')->willReturn(200);
+        $responseTwo->method('getBody')->willReturn('{"data":{}}');
+
+        $this->requestFactory
+            ->expects(self::exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($requestOne, $requestTwo);
+
+        $this->responseFactory
+            ->expects(self::exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($responseOne, $responseTwo);
+
+        $this->frontController
+            ->expects(self::exactly(2))
+            ->method('dispatch')
+            ->with(self::isInstanceOf(Http::class));
+
+        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory, $this->responseFactory);
+        $output = new BufferedOutput();
+
+        $result = $action->execute($output);
+
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertTrue($result->isSuccess());
+        self::assertSame('graphql_pipeline_stress', $result->getOutcomeCode());
+        self::assertSame('GraphQL internal pipeline stress completed successfully', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
+    }
+
+    public function testItContinuesWhenOneDispatchFails(): void
+    {
+        $requestOne = $this->createMock(Http::class);
+        $requestOne->expects(self::once())->method('setPathInfo')->with('/graphql');
+        $requestOne->expects(self::once())->method('setMethod')->with('POST');
+        $requestOne->expects(self::once())->method('setContent')->with(self::isString());
+
+        $requestTwo = $this->createMock(Http::class);
+        $requestTwo->expects(self::once())->method('setPathInfo')->with('/graphql');
+        $requestTwo->expects(self::once())->method('setMethod')->with('POST');
+        $requestTwo->expects(self::once())->method('setContent')->with(self::isString());
+
+        $responseOne = $this->createStub(HttpResponse::class);
+        $responseOne->method('getHttpResponseCode')->willReturn(200);
+        $responseOne->method('getBody')->willReturn('{"data":{}}');
+
+        $responseTwo = $this->createStub(HttpResponse::class);
+        $responseTwo->method('getHttpResponseCode')->willReturn(500);
+        $responseTwo->method('getBody')->willReturn('{"errors":[{"message":"boom"}]}');
+
+        $this->requestFactory
+            ->expects(self::exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($requestOne, $requestTwo);
+
+        $this->responseFactory
+            ->expects(self::exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($responseOne, $responseTwo);
+
+        $calls = 0;
+        $this->frontController
+            ->expects(self::exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(static function (Http $request) use (&$calls): void {
+                $calls++;
+
+                if ($calls === 2) {
+                    throw new RuntimeException('dispatch failed');
+                }
+            });
+
+        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory, $this->responseFactory);
+        $output = new BufferedOutput();
+
+        $result = $action->execute($output);
+
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertFalse($result->isSuccess());
+        self::assertSame('graphql_pipeline_stress', $result->getOutcomeCode());
+        self::assertSame('GraphQL pipeline stress completed with failures', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
+        self::assertStringContainsString('Failed:', implode("\n", $result->getDetails()));
+    }
+}

--- a/Test/Unit/Action/GraphQlInternalPipelineStressTest.php
+++ b/Test/Unit/Action/GraphQlInternalPipelineStressTest.php
@@ -7,7 +7,6 @@ use Magento\Framework\App\FrontControllerInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\Request\HttpFactory;
 use Magento\Framework\App\Response\Http as HttpResponse;
-use Magento\Framework\App\Response\HttpFactory as HttpResponseFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -19,13 +18,11 @@ class GraphQlInternalPipelineStressTest extends TestCase
 {
     private FrontControllerInterface&MockObject $frontController;
     private HttpFactory&MockObject $requestFactory;
-    private HttpResponseFactory&MockObject $responseFactory;
 
     protected function setUp(): void
     {
         $this->frontController = $this->createMock(FrontControllerInterface::class);
         $this->requestFactory = $this->createMock(HttpFactory::class);
-        $this->responseFactory = $this->createMock(HttpResponseFactory::class);
     }
 
     public function testItDispatchesMultipleInternalGraphQlRequests(): void
@@ -53,17 +50,13 @@ class GraphQlInternalPipelineStressTest extends TestCase
             ->method('create')
             ->willReturnOnConsecutiveCalls($requestOne, $requestTwo);
 
-        $this->responseFactory
-            ->expects(self::exactly(2))
-            ->method('create')
-            ->willReturnOnConsecutiveCalls($responseOne, $responseTwo);
-
         $this->frontController
             ->expects(self::exactly(2))
             ->method('dispatch')
-            ->with(self::isInstanceOf(Http::class));
+            ->with(self::isInstanceOf(Http::class))
+            ->willReturnOnConsecutiveCalls($responseOne, $responseTwo);
 
-        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory, $this->responseFactory);
+        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory);
         $output = new BufferedOutput();
 
         $result = $action->execute($output);
@@ -91,33 +84,26 @@ class GraphQlInternalPipelineStressTest extends TestCase
         $responseOne->method('getHttpResponseCode')->willReturn(200);
         $responseOne->method('getBody')->willReturn('{"data":{}}');
 
-        $responseTwo = $this->createStub(HttpResponse::class);
-        $responseTwo->method('getHttpResponseCode')->willReturn(500);
-        $responseTwo->method('getBody')->willReturn('{"errors":[{"message":"boom"}]}');
-
         $this->requestFactory
             ->expects(self::exactly(2))
             ->method('create')
             ->willReturnOnConsecutiveCalls($requestOne, $requestTwo);
 
-        $this->responseFactory
-            ->expects(self::exactly(2))
-            ->method('create')
-            ->willReturnOnConsecutiveCalls($responseOne, $responseTwo);
-
         $calls = 0;
         $this->frontController
             ->expects(self::exactly(2))
             ->method('dispatch')
-            ->willReturnCallback(static function (Http $request) use (&$calls): void {
+            ->willReturnCallback(static function (Http $request) use (&$calls, $responseOne): HttpResponse {
                 $calls++;
 
                 if ($calls === 2) {
                     throw new RuntimeException('dispatch failed');
                 }
+
+                return $responseOne;
             });
 
-        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory, $this->responseFactory);
+        $action = new GraphQlInternalPipelineStress($this->frontController, $this->requestFactory);
         $output = new BufferedOutput();
 
         $result = $action->execute($output);

--- a/Test/Unit/Action/ReindexAllTest.php
+++ b/Test/Unit/Action/ReindexAllTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use ShaunMcManus\ChaosDonkey\Action\ReindexAll;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 class ReindexAllTest extends TestCase
@@ -32,10 +33,15 @@ class ReindexAllTest extends TestCase
 
         $action = new ReindexAll($this->collectionFactory);
 
-        $action->execute($output);
+        $result = $action->execute($output);
 
         self::assertSame(1, $firstIndexer->reindexCalls);
         self::assertSame(1, $secondIndexer->reindexCalls);
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertTrue($result->isSuccess());
+        self::assertSame('reindex_all', $result->getOutcomeCode());
+        self::assertSame('Reindexed all indexers successfully', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
         $printedOutput = $output->fetch();
 
         self::assertStringContainsString('Reindexing all indexers...', $printedOutput);
@@ -58,10 +64,15 @@ class ReindexAllTest extends TestCase
 
         $action = new ReindexAll($this->collectionFactory);
 
-        $action->execute($output);
+        $result = $action->execute($output);
 
         self::assertSame(1, $failingIndexer->reindexCalls);
         self::assertSame(1, $healthyIndexer->reindexCalls);
+        self::assertInstanceOf(ChaosActionResult::class, $result);
+        self::assertFalse($result->isSuccess());
+        self::assertSame('reindex_all', $result->getOutcomeCode());
+        self::assertSame('Reindex completed with failures', $result->getSummary());
+        self::assertCount(2, $result->getDetails());
         $printedOutput = $output->fetch();
 
         self::assertStringContainsString('Failed: failing_indexer (boom)', $printedOutput);

--- a/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
@@ -5,42 +5,45 @@ namespace ShaunMcManus\ChaosDonkey\Test\Unit\Console\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ShaunMcManus\ChaosDonkey\Action\ReindexAll;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
 use ShaunMcManus\ChaosDonkey\Console\Command\ChaosDonkeyKick;
+use ShaunMcManus\ChaosDonkey\Model\ActionPool;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use ShaunMcManus\ChaosDonkey\Model\Config;
 use ShaunMcManus\ChaosDonkey\Model\KickRoller;
+use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
 use ShaunMcManus\ChaosDonkey\Model\StateWriter;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ChaosDonkeyKickTest extends TestCase
 {
     private Config&MockObject $config;
-    private ReindexAll&MockObject $reindexAll;
+    private ActionPool&MockObject $actionPool;
+    private RollOutcomeResolver&MockObject $resolver;
     private StateWriter&MockObject $stateWriter;
     private KickRoller&MockObject $kickRoller;
 
     protected function setUp(): void
     {
         $this->config = $this->createMock(Config::class);
-        $this->reindexAll = $this->createMock(ReindexAll::class);
+        $this->actionPool = $this->createMock(ActionPool::class);
+        $this->resolver = $this->createMock(RollOutcomeResolver::class);
         $this->stateWriter = $this->createMock(StateWriter::class);
         $this->kickRoller = $this->createMock(KickRoller::class);
     }
 
     public function testItExitsEarlyWhenDisabled(): void
     {
-        $this->config
-            ->expects(self::once())
-            ->method('isEnabled')
-            ->willReturn(false);
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(false);
 
         $this->kickRoller->expects(self::never())->method('rollD20');
-        $this->reindexAll->expects(self::never())->method('execute');
+        $this->resolver->expects(self::never())->method('resolve');
+        $this->actionPool->expects(self::never())->method('get');
         $this->stateWriter->expects(self::never())->method('saveLastRun');
         $this->stateWriter->expects(self::never())->method('saveLastKick');
         $this->stateWriter->expects(self::never())->method('saveLastOutcome');
 
-        $command = new ChaosDonkeyKick($this->config, $this->reindexAll, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([]);
@@ -51,31 +54,23 @@ class ChaosDonkeyKickTest extends TestCase
 
     public function testRollOneSavesStateAndPrintsCriticalFailure(): void
     {
-        $this->config
-            ->expects(self::once())
-            ->method('isEnabled')
-            ->willReturn(true);
-        $this->kickRoller
-            ->expects(self::once())
-            ->method('rollD20')
-            ->willReturn(1);
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(1);
+        $this->resolver->expects(self::once())->method('resolve')->with(1)->willReturn('critical_failure');
+        $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
 
-        $this->reindexAll->expects(self::never())->method('execute');
         $this->stateWriter
             ->expects(self::once())
             ->method('saveLastRun')
             ->with(self::callback(static function (string $timestamp): bool {
                 $parsed = \DateTimeImmutable::createFromFormat(DATE_ATOM, $timestamp);
-                if ($parsed === false) {
-                    return false;
-                }
 
-                return $parsed->format(DATE_ATOM) === $timestamp;
+                return $parsed !== false && $parsed->format(DATE_ATOM) === $timestamp;
             }));
         $this->stateWriter->expects(self::once())->method('saveLastKick')->with(1);
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
 
-        $command = new ChaosDonkeyKick($this->config, $this->reindexAll, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $tester = new CommandTester($command);
 
         $tester->execute([]);
@@ -84,47 +79,62 @@ class ChaosDonkeyKickTest extends TestCase
         self::assertStringContainsString('Critical Failure!', $tester->getDisplay());
     }
 
-    public function testRollTwoTriggersReindexAndPersistsOutcome(): void
+    public function testRollThreeTriggersMappedAction(): void
     {
-        $this->config
-            ->expects(self::once())
-            ->method('isEnabled')
-            ->willReturn(true);
-        $this->kickRoller
-            ->expects(self::once())
-            ->method('rollD20')
-            ->willReturn(2);
+        $action = $this->createStub(ChaosActionInterface::class);
+        $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'ok'));
 
-        $this->reindexAll->expects(self::once())->method('execute');
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
+        $this->resolver->expects(self::once())->method('resolve')->with(3)->willReturn('cache_flush');
+        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
+
         $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(2);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('reindex_all');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
 
-        $command = new ChaosDonkeyKick($this->config, $this->reindexAll, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $tester = new CommandTester($command);
 
         $tester->execute([]);
 
-        self::assertStringContainsString('You rolled a 2', $tester->getDisplay());
+        self::assertStringContainsString('You rolled a 3', $tester->getDisplay());
+    }
+
+    public function testRollFourTriggersMappedAction(): void
+    {
+        $action = $this->createStub(ChaosActionInterface::class);
+        $action->method('execute')->willReturn(new ChaosActionResult('graphql_pipeline_stress', 'ok'));
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(4);
+        $this->resolver->expects(self::once())->method('resolve')->with(4)->willReturn('graphql_pipeline_stress');
+        $this->actionPool->expects(self::once())->method('get')->with('graphql_pipeline_stress')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(4);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('graphql_pipeline_stress');
+
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertStringContainsString('You rolled a 4', $tester->getDisplay());
     }
 
     public function testRollTwentySavesStateAndPrintsCriticalSuccess(): void
     {
-        $this->config
-            ->expects(self::once())
-            ->method('isEnabled')
-            ->willReturn(true);
-        $this->kickRoller
-            ->expects(self::once())
-            ->method('rollD20')
-            ->willReturn(20);
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(20);
+        $this->resolver->expects(self::once())->method('resolve')->with(20)->willReturn('critical_success');
+        $this->actionPool->expects(self::once())->method('get')->with('critical_success')->willReturn(null);
 
-        $this->reindexAll->expects(self::never())->method('execute');
         $this->stateWriter->expects(self::once())->method('saveLastRun');
         $this->stateWriter->expects(self::once())->method('saveLastKick')->with(20);
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_success');
 
-        $command = new ChaosDonkeyKick($this->config, $this->reindexAll, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $tester = new CommandTester($command);
 
         $tester->execute([]);
@@ -135,21 +145,16 @@ class ChaosDonkeyKickTest extends TestCase
 
     public function testDefaultRollSavesStateAndPrintsNappingMessage(): void
     {
-        $this->config
-            ->expects(self::once())
-            ->method('isEnabled')
-            ->willReturn(true);
-        $this->kickRoller
-            ->expects(self::once())
-            ->method('rollD20')
-            ->willReturn(6);
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(6);
+        $this->resolver->expects(self::once())->method('resolve')->with(6)->willReturn('napping');
+        $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
 
-        $this->reindexAll->expects(self::never())->method('execute');
         $this->stateWriter->expects(self::once())->method('saveLastRun');
         $this->stateWriter->expects(self::once())->method('saveLastKick')->with(6);
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
 
-        $command = new ChaosDonkeyKick($this->config, $this->reindexAll, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $tester = new CommandTester($command);
 
         $tester->execute([]);

--- a/Test/Unit/Model/ActionPoolTest.php
+++ b/Test/Unit/Model/ActionPoolTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ActionPool;
+
+class ActionPoolTest extends TestCase
+{
+    public function testItReturnsActionForKnownCode(): void
+    {
+        $reindexAction = $this->createStub(ChaosActionInterface::class);
+
+        $pool = new ActionPool([
+            'reindex_all' => $reindexAction,
+        ]);
+
+        self::assertSame($reindexAction, $pool->get('reindex_all'));
+    }
+
+    public function testItReturnsNullForUnknownCode(): void
+    {
+        $reindexAction = $this->createStub(ChaosActionInterface::class);
+
+        $pool = new ActionPool([
+            'reindex_all' => $reindexAction,
+        ]);
+
+        self::assertNull($pool->get('not_registered'));
+    }
+}

--- a/Test/Unit/Model/RollOutcomeResolverTest.php
+++ b/Test/Unit/Model/RollOutcomeResolverTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
+
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
+
+class RollOutcomeResolverTest extends TestCase
+{
+    public function testItResolvesConfiguredRollOutcomes(): void
+    {
+        $resolver = new RollOutcomeResolver();
+
+        self::assertSame('reindex_all', $resolver->resolve(2));
+        self::assertSame('cache_flush', $resolver->resolve(3));
+        self::assertSame('graphql_pipeline_stress', $resolver->resolve(4));
+        self::assertSame('critical_failure', $resolver->resolve(1));
+        self::assertSame('critical_success', $resolver->resolve(20));
+        self::assertSame('napping', $resolver->resolve(6));
+    }
+}

--- a/docs/superpowers/plans/2026-03-28-chaos-actions-phase-1-implementation-plan.md
+++ b/docs/superpowers/plans/2026-03-28-chaos-actions-phase-1-implementation-plan.md
@@ -1,0 +1,332 @@
+# Chaos Actions Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Magento-native chaos action framework and deliver two new actions (`cache_flush`, `graphql_pipeline_stress`) while preserving and integrating `reindex_all`.
+
+**Architecture:** Introduce an action interface + DI action pool + roll outcome resolver so `chaosdonkey:kick` becomes a thin orchestrator. Implement each chaos behavior as an isolated action service that returns a structured result object. Keep status/state writing in existing services and preserve operator-friendly CLI output.
+
+**Tech Stack:** PHP 8.5, Magento 2 module DI/config, Symfony Console commands, PHPUnit 12
+
+---
+
+## Scope and Boundaries
+- In scope: action framework, roll resolution, kick command integration, cache flush action, internal GraphQL pipeline stress action, tests/docs updates.
+- Out of scope: admin-driven action builders/toggles/probabilities, cron scheduling/automation.
+
+## File Map
+
+### Create
+- `Api/ChaosActionInterface.php` (action contract)
+- `Model/ChaosActionResult.php` (standardized action execution result)
+- `Model/ActionPool.php` (action lookup by code)
+- `Model/RollOutcomeResolver.php` (d20 -> outcome/action code mapping)
+- `Action/CacheFlush.php` (new action)
+- `Action/GraphQlInternalPipelineStress.php` (new action)
+- `Test/Unit/Model/ActionPoolTest.php`
+- `Test/Unit/Model/RollOutcomeResolverTest.php`
+- `Test/Unit/Action/CacheFlushTest.php`
+- `Test/Unit/Action/GraphQlInternalPipelineStressTest.php`
+- minimal Magento/Symfony stub files if required by unit tests for new interfaces/services
+
+### Modify
+- `Action/ReindexAll.php` (implement interface + return `ChaosActionResult`)
+- `Console/Command/ChaosDonkeyKick.php` (resolver + pool orchestration)
+- `etc/di.xml` (register pool items and resolver dependencies)
+- `README.md` (document new action mapping and behavior)
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php` (new outcomes and action execution assertions)
+
+### Verify Existing
+- `Test/Unit/Console/Command/ChaosDonkeyStatusTest.php`
+- `Test/Unit/Model/ConfigTest.php`
+- `Test/Unit/Model/StateWriterTest.php`
+- `Test/Unit/Action/ReindexAllTest.php`
+
+---
+
+### Task 1: Introduce Action Contracts and Resolver Core
+
+**Files:**
+- Create: `Api/ChaosActionInterface.php`
+- Create: `Model/ChaosActionResult.php`
+- Create: `Model/RollOutcomeResolver.php`
+- Test: `Test/Unit/Model/RollOutcomeResolverTest.php`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+```php
+self::assertSame('reindex_all', $resolver->resolve(2));
+self::assertSame('cache_flush', $resolver->resolve(3));
+self::assertSame('graphql_pipeline_stress', $resolver->resolve(4));
+self::assertSame('critical_failure', $resolver->resolve(1));
+self::assertSame('critical_success', $resolver->resolve(20));
+self::assertSame('napping', $resolver->resolve(6));
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Model/RollOutcomeResolverTest.php`
+Expected: FAIL (class not found / methods missing)
+
+- [ ] **Step 3: Implement minimal contracts and resolver**
+
+- Add interface with:
+  - `getCode(): string`
+  - `execute(OutputInterface $output): ChaosActionResult`
+- Add result value object with constructor/getters.
+- Implement resolver with fixed mapping from spec.
+
+- [ ] **Step 4: Run resolver test to verify GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Model/RollOutcomeResolverTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Api/ChaosActionInterface.php Model/ChaosActionResult.php Model/RollOutcomeResolver.php Test/Unit/Model/RollOutcomeResolverTest.php
+git commit -m "Add chaos action contract and roll outcome resolver"
+```
+
+---
+
+### Task 2: Add ActionPool Service
+
+**Files:**
+- Create: `Model/ActionPool.php`
+- Test: `Test/Unit/Model/ActionPoolTest.php`
+
+- [ ] **Step 1: Write failing tests for known and unknown action codes**
+
+```php
+self::assertSame($reindexAction, $pool->get('reindex_all'));
+self::assertNull($pool->get('not_registered'));
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Model/ActionPoolTest.php`
+Expected: FAIL
+
+- [ ] **Step 3: Implement minimal `ActionPool`**
+- Constructor accepts array of `ChaosActionInterface` keyed by code.
+- `get(string $code): ?ChaosActionInterface`
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Model/ActionPoolTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Model/ActionPool.php Test/Unit/Model/ActionPoolTest.php
+git commit -m "Add action pool for chaos action resolution"
+```
+
+---
+
+### Task 3: Adapt Reindex Action to Framework
+
+**Files:**
+- Modify: `Action/ReindexAll.php`
+- Modify: `Test/Unit/Action/ReindexAllTest.php`
+
+- [ ] **Step 1: Update tests to assert `ChaosActionResult` output contract**
+- Keep existing per-indexer continue-on-error assertions.
+
+- [ ] **Step 2: Run RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/ReindexAllTest.php`
+Expected: FAIL
+
+- [ ] **Step 3: Implement interface + result return in `ReindexAll`**
+- Keep current progress output.
+- Return structured summary and success flag.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/ReindexAllTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Action/ReindexAll.php Test/Unit/Action/ReindexAllTest.php
+git commit -m "Adapt reindex action to chaos action interface"
+```
+
+---
+
+### Task 4: Implement CacheFlush Action
+
+**Files:**
+- Create: `Action/CacheFlush.php`
+- Create: `Test/Unit/Action/CacheFlushTest.php`
+- Update stubs only if required
+
+- [ ] **Step 1: Write failing tests for full success and partial failure**
+- Assert all cache types attempted.
+- Assert failures are captured but execution continues.
+
+- [ ] **Step 2: Run RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/CacheFlushTest.php`
+Expected: FAIL
+
+- [ ] **Step 3: Implement minimal action**
+- Use Magento cache management APIs.
+- Return `ChaosActionResult` with details.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/CacheFlushTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Action/CacheFlush.php Test/Unit/Action/CacheFlushTest.php
+git commit -m "Add cache flush chaos action"
+```
+
+---
+
+### Task 5: Implement Internal GraphQL Pipeline Stress Action
+
+**Files:**
+- Create: `Action/GraphQlInternalPipelineStress.php`
+- Create: `Test/Unit/Action/GraphQlInternalPipelineStressTest.php`
+- Update/add stubs for internal request/dispatch dependencies as needed
+
+- [ ] **Step 1: Write failing tests for internal dispatch orchestration**
+- Assert synthetic request targets `/graphql`.
+- Assert multiple payloads are dispatched.
+- Assert failures aggregate and do not abort remaining payloads.
+
+- [ ] **Step 2: Run RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/GraphQlInternalPipelineStressTest.php`
+Expected: FAIL
+
+- [ ] **Step 3: Implement minimal action**
+- Hardcode initial payload list (Phase 1 default).
+- Dispatch through internal Magento HTTP pipeline path (no external HTTP client).
+- Aggregate metadata/errors into result.
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Action/GraphQlInternalPipelineStressTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Action/GraphQlInternalPipelineStress.php Test/Unit/Action/GraphQlInternalPipelineStressTest.php
+git commit -m "Add internal GraphQL pipeline stress chaos action"
+```
+
+---
+
+### Task 6: Wire DI Pool and Refactor Kick Command Orchestration
+
+**Files:**
+- Modify: `etc/di.xml`
+- Modify: `Console/Command/ChaosDonkeyKick.php`
+- Modify: `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+
+- [ ] **Step 1: Write failing command tests for roll `3` and `4` action execution**
+- Assert resolver output controls action selection.
+- Assert state persistence still occurs.
+
+- [ ] **Step 2: Run RED**
+
+Run: `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+Expected: FAIL
+
+- [ ] **Step 3: Implement orchestration updates**
+- Inject `RollOutcomeResolver` and `ActionPool`.
+- Resolve roll code and execute action if mapped.
+- Keep existing disabled-gate and state writer behavior.
+
+- [ ] **Step 4: Wire actions in `etc/di.xml`**
+- Register actions in pool keyed by code.
+
+- [ ] **Step 5: Run GREEN**
+
+Run: `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Console/Command/ChaosDonkeyKick.php etc/di.xml Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+git commit -m "Refactor kick command to use resolver and action pool"
+```
+
+---
+
+### Task 7: Documentation and Full Verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README with new roll mapping and action behavior**
+- Document `cache_flush` and `graphql_pipeline_stress`.
+- Document Phase 1 default payload behavior for GraphQL action.
+
+- [ ] **Step 2: Run complete unit suite**
+
+Run: `vendor/bin/phpunit`
+Expected: PASS (no errors, no notices)
+
+- [ ] **Step 3: Optional Magento runtime smoke validation**
+
+Run in Magento env:
+- `bin/magento chaosdonkey:status`
+- `bin/magento config:set admin/chaos_donkey/enabled 1`
+- `bin/magento chaosdonkey:kick`
+
+Expected: mapped action output and status updates.
+
+- [ ] **Step 4: Commit docs updates**
+
+```bash
+git add README.md
+git commit -m "Document phase 1 chaos action framework and mappings"
+```
+
+---
+
+### Task 8: Final Verification Gate (Required)
+
+**Files:**
+- No additional code changes expected unless regressions found
+
+- [ ] **Step 1: Run final verification commands**
+
+```bash
+vendor/bin/phpunit
+git status --short
+```
+
+Expected:
+- test suite fully green
+- working tree clean except intentionally untracked local files
+
+- [ ] **Step 2: If regressions found, fix and re-run verification**
+
+- [ ] **Step 3: Hand off to `finishing-a-development-branch` workflow**
+
+---
+
+## Skills to Apply During Execution
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `superpowers:receiving-code-review` (if review comments arrive)
+- `superpowers:finishing-a-development-branch` (after all tasks)
+
+## Commit Strategy
+- One commit per task.
+- Avoid batching unrelated file changes.
+- Keep commit messages imperative and scoped.

--- a/docs/superpowers/specs/2026-03-28-chaos-actions-phase-1-design.md
+++ b/docs/superpowers/specs/2026-03-28-chaos-actions-phase-1-design.md
@@ -1,0 +1,122 @@
+# ChaosDonkey Phase 1 Design: Action Framework + Cache Flush + Internal GraphQL Pipeline Stress
+
+Date: 2026-03-28
+Scope: Sub-project 1 only (future phases will cover admin UX/config expansion and cron automation)
+
+## Goal
+Implement Magento-native chaos action extensibility with three operational actions in framework form:
+- `reindex_all` (existing behavior, framework-adapted)
+- `cache_flush` (new)
+- `graphql_pipeline_stress` (new, internal HTTP pipeline path, no outbound HTTP)
+
+## Architecture
+Use interface-driven action services and DI action pool wiring:
+- `Api/ChaosActionInterface`
+- `Model/ChaosActionResult`
+- `Model/ActionPool`
+- `Model/RollOutcomeResolver`
+- Action services under `Action/`
+- Thin orchestration in `Console/Command/ChaosDonkeyKick`
+
+`ChaosDonkeyKick` responsibilities:
+1. Enabled gate check
+2. Roll D20
+3. Resolve roll -> outcome code
+4. Execute mapped action via pool (if mapped)
+5. Print summary/details
+6. Persist `last_run`, `last_kick`, `last_outcome`
+
+## Components
+### `Api/ChaosActionInterface`
+- `public function getCode(): string`
+- `public function execute(OutputInterface $output): ChaosActionResult`
+
+### `Model/ChaosActionResult`
+Payload object with:
+- `outcomeCode`
+- `summary`
+- `details` (list)
+- `success` (bool)
+
+### `Model/ActionPool`
+- Inject array of `ChaosActionInterface` actions from `etc/di.xml`
+- Resolve by code
+- Return explicit failure when code is unknown
+
+### `Model/RollOutcomeResolver`
+Initial fixed mapping for Phase 1:
+- `2` => `reindex_all`
+- `3` => `cache_flush`
+- `4` => `graphql_pipeline_stress`
+- `1` => `critical_failure`
+- `20` => `critical_success`
+- default => `napping`
+
+### `Action/ReindexAll`
+- Implement `ChaosActionInterface`
+- Iterate indexers and continue on per-indexer failure
+
+### `Action/CacheFlush`
+- Implement `ChaosActionInterface`
+- Use Magento cache management services to flush cache types
+- Report flushed types and failures
+
+### `Action/GraphQlInternalPipelineStress`
+- Implement `ChaosActionInterface`
+- Build synthetic in-process request(s) targeting `/graphql`
+- Dispatch through Magento internal HTTP pipeline (front controller path)
+- Capture response metadata and GraphQL errors
+- Aggregate summary/details
+
+## Data Flow
+1. Command starts.
+2. If disabled: emit message and return success (no state write).
+3. Roll D20.
+4. Resolve outcome code.
+5. If outcome has action: execute action and print results.
+6. If outcome is message-only: print mapped message.
+7. Persist run metadata.
+8. Return success.
+
+GraphQL stress action path:
+1. Create default GraphQL payload set (hardcoded for Phase 1).
+2. For each payload, synthesize internal request to `/graphql`.
+3. Dispatch via Magento internal HTTP app pipeline.
+4. Record status/errors/summary.
+5. Return aggregated result.
+
+## Error Handling
+- Command does not crash on expected chaos failures; keeps operator-friendly output.
+- Persist run metadata even when action reports failures.
+- Action-specific behavior:
+  - Reindex: continue on indexer errors.
+  - Cache flush: continue through all targeted types.
+  - GraphQL stress: continue through payload set and aggregate failures.
+- Unknown action code: output explicit warning and store `unknown_action`.
+
+## Testing Strategy
+### Unit tests
+- `ActionPool`: resolve and unknown behavior
+- `RollOutcomeResolver`: mapping correctness
+- `CacheFlush`: full success and partial failure
+- `GraphQlInternalPipelineStress`: internal dispatch orchestration with mocked services
+- `ChaosDonkeyKick`: new outcome mappings + state persistence
+
+### Existing tests adapted/kept
+- Reindex behavior tests
+- Status rendering tests
+- Config/state writer tests
+- Kick roller bounds tests
+
+### Magento manual verification
+- Enable module, run `chaosdonkey:kick` until actions trigger
+- Verify output and status fields update correctly
+- Validate GraphQL stress action confirms internal pipeline path
+
+## Out of Scope (Future Phases)
+- Admin-driven GraphQL query builder/templates
+- Admin action toggles and probability controls
+- Cron scheduling and automated chaos runs
+
+## Recommendation
+Implement this phase with fixed default mappings and hardcoded GraphQL payloads, then expand configurability in Phase 2 and scheduling in Phase 3.

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="ShaunMcManus\ChaosDonkey\Model\ActionPool">
+        <arguments>
+            <argument name="actions" xsi:type="array">
+                <item name="reindex_all" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\ReindexAll</item>
+                <item name="cache_flush" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\CacheFlush</item>
+                <item name="graphql_pipeline_stress" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\GraphQlInternalPipelineStress</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
## Summary
- add a Magento-native chaos action framework (`ChaosActionInterface`, `ChaosActionResult`, `ActionPool`, `RollOutcomeResolver`)
- add new actions: `CacheFlush` and `GraphQlInternalPipelineStress`
- adapt `ReindexAll` to action-interface/result model
- refactor `chaosdonkey:kick` to resolve outcomes and execute DI-wired actions
- wire action pool in `etc/di.xml`
- add unit tests for resolver/pool/actions/kick orchestration
- update README for new roll mappings and behavior

## Validation
- `vendor/bin/phpunit` (26 tests, 2187 assertions)
