### PR TITLE
@codex Phase 2A: admin action toggles and kick reroll behavior

### DIFF
--- a/Console/Command/ChaosDonkeyKick.php
+++ b/Console/Command/ChaosDonkeyKick.php
@@ -14,6 +14,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ChaosDonkeyKick extends Command
 {
+    private const MAX_REROLL_ATTEMPTS = 20;
+    private const ACTION_CODES = [
+        'reindex_all',
+        'cache_flush',
+        'graphql_pipeline_stress',
+    ];
+
     private Config $config;
     private ActionPool $actionPool;
     private RollOutcomeResolver $resolver;
@@ -57,8 +64,28 @@ class ChaosDonkeyKick extends Command
             return Command::SUCCESS;
         }
 
-        $kick = $this->kickRoller->rollD20();
-        $outcome = $this->resolver->resolve($kick);
+        $enabledActions = $this->getEnabledActions();
+        if (!in_array(true, $enabledActions, true)) {
+            $output->writeln('All configured chaos actions are disabled. Rolling non-action outcomes only.');
+        }
+
+        $kick = 0;
+        $outcome = 'napping';
+
+        for ($attempt = 0; $attempt < self::MAX_REROLL_ATTEMPTS; $attempt++) {
+            $kick = $this->kickRoller->rollD20();
+            $outcome = $this->resolver->resolve($kick);
+
+            if (!$this->isDisabledActionOutcome($outcome, $enabledActions)) {
+                break;
+            }
+        }
+
+        if ($this->isDisabledActionOutcome($outcome, $enabledActions)) {
+            $outcome = 'napping';
+            $output->writeln('Max reroll attempts reached. Falling back to napping.');
+        }
+
         $output->writeln('ChaosDonkeyKick kicks your Magento. You rolled a ' . $kick);
 
         $action = $this->actionPool->get($outcome);
@@ -79,5 +106,31 @@ class ChaosDonkeyKick extends Command
         $this->stateWriter->saveLastOutcome($outcome);
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function getEnabledActions(): array
+    {
+        $enabledActions = [];
+
+        foreach (self::ACTION_CODES as $actionCode) {
+            $enabledActions[$actionCode] = $this->config->isActionEnabled($actionCode);
+        }
+
+        return $enabledActions;
+    }
+
+    /**
+     * @param array<string, bool> $enabledActions
+     */
+    private function isDisabledActionOutcome(string $outcome, array $enabledActions): bool
+    {
+        if (!array_key_exists($outcome, $enabledActions)) {
+            return false;
+        }
+
+        return $enabledActions[$outcome] === false;
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -9,6 +9,9 @@ use Magento\Store\Model\ScopeInterface;
 class Config
 {
     public const CONFIG_PATH_ENABLED = 'admin/chaos_donkey/enabled';
+    public const CONFIG_PATH_ENABLE_REINDEX_ALL = 'admin/chaos_donkey/enable_reindex_all';
+    public const CONFIG_PATH_ENABLE_CACHE_FLUSH = 'admin/chaos_donkey/enable_cache_flush';
+    public const CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS = 'admin/chaos_donkey/enable_graphql_pipeline_stress';
     public const CONFIG_PATH_LAST_RUN = 'admin/chaos_donkey/last_run';
     public const CONFIG_PATH_LAST_KICK = 'admin/chaos_donkey/last_kick';
     public const CONFIG_PATH_LAST_OUTCOME = 'admin/chaos_donkey/last_outcome';
@@ -27,6 +30,31 @@ class Config
     public function isEnabled(string $scopeType = ScopeInterface::SCOPE_STORE, ?string $scopeCode = null): bool
     {
         return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLED, $scopeType, $scopeCode);
+    }
+
+    public function isReindexAllEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_REINDEX_ALL, $scopeType, $scopeCode);
+    }
+
+    public function isCacheFlushEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_CACHE_FLUSH, $scopeType, $scopeCode);
+    }
+
+    public function isGraphQlPipelineStressEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS, $scopeType, $scopeCode);
+    }
+
+    public function isActionEnabled(string $actionCode): bool
+    {
+        return match ($actionCode) {
+            'reindex_all' => $this->isReindexAllEnabled(),
+            'cache_flush' => $this->isCacheFlushEnabled(),
+            'graphql_pipeline_stress' => $this->isGraphQlPipelineStressEnabled(),
+            default => true,
+        };
     }
 
     public function getLastRun(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): ?string

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Magento 2 module to cause operational chaos on command.
 Rolls a D20 and executes a mapped outcome.
 
 - If `admin/chaos_donkey/enabled` is disabled, exits early with a clear message.
+- Before executing an action outcome, checks action toggles:
+  - `admin/chaos_donkey/enable_reindex_all`
+  - `admin/chaos_donkey/enable_cache_flush`
+  - `admin/chaos_donkey/enable_graphql_pipeline_stress`
+- If a disabled action outcome is rolled, rerolls up to 20 times.
+- If all action toggles are disabled, prints `All configured chaos actions are disabled. Rolling non-action outcomes only.`
+- If reroll attempts are exhausted, falls back to `napping`.
 - If enabled, saves:
   - `admin/chaos_donkey/last_run` (ISO-8601 timestamp)
   - `admin/chaos_donkey/last_kick` (rolled value)

--- a/README.md
+++ b/README.md
@@ -59,3 +59,19 @@ This repository contains standalone unit tests for module logic and command orch
 composer install
 vendor/bin/phpunit
 ```
+
+## Simplified PR Workflow
+
+Use the helper scripts in `scripts/` for a shorter GitHub flow.
+
+Start work on a new branch and open a PR draft/fill flow:
+
+```bash
+scripts/pr-start.sh feat/my-change
+```
+
+Merge PR with squash, delete branches, and sync local `main`:
+
+```bash
+scripts/pr-finish.sh
+```

--- a/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
@@ -85,6 +85,7 @@ class ChaosDonkeyKickTest extends TestCase
         $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'ok'));
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->method('isActionEnabled')->willReturn(true);
         $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
         $this->resolver->expects(self::once())->method('resolve')->with(3)->willReturn('cache_flush');
         $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
@@ -107,6 +108,7 @@ class ChaosDonkeyKickTest extends TestCase
         $action->method('execute')->willReturn(new ChaosActionResult('graphql_pipeline_stress', 'ok'));
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->method('isActionEnabled')->willReturn(true);
         $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(4);
         $this->resolver->expects(self::once())->method('resolve')->with(4)->willReturn('graphql_pipeline_stress');
         $this->actionPool->expects(self::once())->method('get')->with('graphql_pipeline_stress')->willReturn($action);
@@ -160,6 +162,119 @@ class ChaosDonkeyKickTest extends TestCase
         $tester->execute([]);
 
         self::assertStringContainsString('You rolled a 6', $tester->getDisplay());
+        self::assertStringContainsString('The donkeys are napping', $tester->getDisplay());
+    }
+
+    public function testDisabledActionOutcomeTriggersRerollAndPersistsFinalOutcome(): void
+    {
+        $action = $this->createStub(ChaosActionInterface::class);
+        $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'ok'));
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', false],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+            ]);
+        $this->kickRoller->expects(self::exactly(2))
+            ->method('rollD20')
+            ->willReturnOnConsecutiveCalls(2, 3);
+        $resolvedRolls = [];
+        $this->resolver->expects(self::exactly(2))
+            ->method('resolve')
+            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
+                $resolvedRolls[] = $kick;
+
+                return match ($kick) {
+                    2 => 'reindex_all',
+                    3 => 'cache_flush',
+                };
+            });
+        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
+
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame([2, 3], $resolvedRolls);
+        self::assertStringContainsString('You rolled a 3', $tester->getDisplay());
+        self::assertStringNotContainsString('You rolled a 2', $tester->getDisplay());
+    }
+
+    public function testAllActionsDisabledWarnsOnceAndExecutesOnlyNonActionOutcome(): void
+    {
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturn(false);
+        $this->kickRoller->expects(self::exactly(4))
+            ->method('rollD20')
+            ->willReturnOnConsecutiveCalls(2, 3, 4, 1);
+        $resolvedRolls = [];
+        $this->resolver->expects(self::exactly(4))
+            ->method('resolve')
+            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
+                $resolvedRolls[] = $kick;
+
+                return match ($kick) {
+                    1 => 'critical_failure',
+                    2 => 'reindex_all',
+                    3 => 'cache_flush',
+                    4 => 'graphql_pipeline_stress',
+                };
+            });
+        $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(1);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
+
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertSame([2, 3, 4, 1], $resolvedRolls);
+        self::assertSame(
+            1,
+            substr_count($tester->getDisplay(), 'All configured chaos actions are disabled. Rolling non-action outcomes only.')
+        );
+        self::assertStringContainsString('You rolled a 1', $tester->getDisplay());
+        self::assertStringContainsString('Critical Failure!', $tester->getDisplay());
+    }
+
+    public function testMaxAttemptGuardFallsBackToNapping(): void
+    {
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', false],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+            ]);
+        $this->kickRoller->expects(self::exactly(20))->method('rollD20')->willReturn(2);
+        $this->resolver->expects(self::exactly(20))->method('resolve')->with(2)->willReturn('reindex_all');
+        $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(2);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
+
+        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        self::assertStringContainsString('Max reroll attempts reached. Falling back to napping.', $tester->getDisplay());
+        self::assertStringContainsString('You rolled a 2', $tester->getDisplay());
         self::assertStringContainsString('The donkeys are napping', $tester->getDisplay());
     }
 }

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use ShaunMcManus\ChaosDonkey\Model\Config;
@@ -28,6 +29,45 @@ class ConfigTest extends TestCase
         $config = new Config($this->scopeConfig);
 
         self::assertTrue($config->isEnabled());
+    }
+
+    public function testItReadsReindexAllEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_REINDEX_ALL, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isReindexAllEnabled());
+    }
+
+    public function testItReadsCacheFlushEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_CACHE_FLUSH, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isCacheFlushEnabled());
+    }
+
+    public function testItReadsGraphQlPipelineStressEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isGraphQlPipelineStressEnabled());
     }
 
     public function testItReadsLastRunFromExpectedPath(): void
@@ -81,5 +121,48 @@ class ConfigTest extends TestCase
         self::assertNull($config->getLastRun());
         self::assertNull($config->getLastKick());
         self::assertNull($config->getLastOutcome());
+    }
+
+    #[DataProvider('actionCodeMappingProvider')]
+    public function testItMapsActionCodesToTheirMatchingToggle(string $actionCode, string $expectedConfigPath): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with($expectedConfigPath, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isActionEnabled($actionCode));
+    }
+
+    public function testItAllowsUnknownActionCodesByDefault(): void
+    {
+        $this->scopeConfig
+            ->expects(self::never())
+            ->method('isSetFlag');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isActionEnabled('napping'));
+    }
+
+    public static function actionCodeMappingProvider(): array
+    {
+        return [
+            'reindex all' => [
+                'reindex_all',
+                Config::CONFIG_PATH_ENABLE_REINDEX_ALL,
+            ],
+            'cache flush' => [
+                'cache_flush',
+                Config::CONFIG_PATH_ENABLE_CACHE_FLUSH,
+            ],
+            'graphql pipeline stress' => [
+                'graphql_pipeline_stress',
+                Config::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS,
+            ],
+        ];
     }
 }

--- a/docs/superpowers/plans/2026-03-28-chaos-actions-phase-2a-admin-toggles-implementation-plan.md
+++ b/docs/superpowers/plans/2026-03-28-chaos-actions-phase-2a-admin-toggles-implementation-plan.md
@@ -1,0 +1,186 @@
+# Chaos Actions Phase 2A Admin Toggles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add admin-configurable per-action enable/disable toggles and make `chaosdonkey:kick` reroll away from disabled action outcomes.
+
+**Architecture:** Keep existing action framework unchanged. Add config fields/getters for action toggles and update kick orchestration to reroll when disabled action outcomes are selected, with explicit operator warnings and a max-attempt guard fallback.
+
+**Tech Stack:** PHP 8.5, Magento 2 system config XML, Symfony Console, PHPUnit 12
+
+---
+
+## Scope and Boundaries
+- In scope: action toggle config fields, config model accessors, reroll logic in kick command, unit tests, docs update.
+- Out of scope: probability controls, per-store overrides, GraphQL payload builder, cron automation.
+
+## File Map
+
+### Modify
+- `etc/adminhtml/system.xml`
+- `etc/config.xml`
+- `Model/Config.php`
+- `Console/Command/ChaosDonkeyKick.php`
+- `Test/Unit/Model/ConfigTest.php`
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+- `README.md`
+
+### Verify Existing
+- `Test/Unit/Action/*.php`
+- `Test/Unit/Console/Command/ChaosDonkeyStatusTest.php`
+
+---
+
+### Task 1: Add Admin Toggle Fields and Default Values
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml`
+- Modify: `etc/config.xml`
+
+- [ ] **Step 1: Add failing XML expectations via lightweight structure assertions**
+- Add or update XML tests if present; if not, proceed with direct XML edit and rely on integration/manual verification.
+
+- [ ] **Step 2: Implement XML fields**
+- Add yes/no fields under `admin/chaos_donkey`:
+  - `enable_reindex_all`
+  - `enable_cache_flush`
+  - `enable_graphql_pipeline_stress`
+- Add defaults in `etc/config.xml` as `1` for each toggle.
+
+- [ ] **Step 3: Run focused verification**
+Run: `vendor/bin/phpunit`
+Expected: suite remains green.
+
+- [ ] **Step 4: Commit**
+```bash
+git add etc/adminhtml/system.xml etc/config.xml
+git commit -m "Add admin action toggle config fields"
+```
+
+---
+
+### Task 2: Extend Config Model for Action Toggle Access
+
+**Files:**
+- Modify: `Model/Config.php`
+- Modify: `Test/Unit/Model/ConfigTest.php`
+
+- [ ] **Step 1: Write failing tests**
+- Add tests for new getters:
+  - `isReindexAllEnabled()`
+  - `isCacheFlushEnabled()`
+  - `isGraphQlPipelineStressEnabled()`
+- Add tests for `isActionEnabled(string $actionCode): bool` mapping and unknown-code behavior.
+
+- [ ] **Step 2: Run RED**
+Run: `vendor/bin/phpunit Test/Unit/Model/ConfigTest.php`
+Expected: FAIL for missing methods/constants.
+
+- [ ] **Step 3: Implement minimal Config changes**
+- Add constants for three config paths.
+- Add boolean getters using `isSetFlag`.
+- Add `isActionEnabled()` mapping:
+  - `reindex_all` => reindex toggle
+  - `cache_flush` => cache toggle
+  - `graphql_pipeline_stress` => graphql toggle
+  - non-action outcomes / unknown => `true`
+
+- [ ] **Step 4: Run GREEN**
+Run: `vendor/bin/phpunit Test/Unit/Model/ConfigTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "Add action toggle getters and isActionEnabled config mapping"
+```
+
+---
+
+### Task 3: Add Disabled-Action Reroll Logic in Kick Command
+
+**Files:**
+- Modify: `Console/Command/ChaosDonkeyKick.php`
+- Modify: `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+
+- [ ] **Step 1: Write failing tests for new behavior**
+Add tests for:
+- disabled action result triggers reroll
+- all-actions-disabled warning logs and only non-action outcomes execute
+- max-attempt guard falls back to `napping`
+- persisted `last_kick` and `last_outcome` reflect final executed outcome
+
+- [ ] **Step 2: Run RED**
+Run: `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+Expected: FAIL for missing reroll logic/warnings.
+
+- [ ] **Step 3: Implement minimal reroll flow**
+- Determine enabled action flags from `Config`.
+- Roll and resolve in a bounded loop.
+- If selected outcome is disabled action, reroll.
+- Log all-actions-disabled warning once when applicable.
+- On max-attempt exceed: set outcome to `napping` and log warning.
+- Keep existing persistence and output semantics.
+
+- [ ] **Step 4: Run GREEN**
+Run: `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add Console/Command/ChaosDonkeyKick.php Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+git commit -m "Skip disabled actions in kick command via bounded reroll"
+```
+
+---
+
+### Task 4: Documentation and Full Verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README**
+- Document new admin action toggles and reroll behavior.
+- Document all-actions-disabled warning behavior.
+
+- [ ] **Step 2: Run full verification**
+Run: `vendor/bin/phpunit`
+Expected: all tests pass, no notices/deprecations newly introduced.
+
+- [ ] **Step 3: Commit docs**
+```bash
+git add README.md
+git commit -m "Document Phase 2A action toggle and reroll behavior"
+```
+
+---
+
+### Task 5: Final Verification Gate
+
+**Files:**
+- No code changes expected unless regressions discovered
+
+- [ ] **Step 1: Final command set**
+```bash
+vendor/bin/phpunit
+git status --short
+```
+Expected:
+- test suite green
+- clean working tree (excluding intentional untracked files)
+
+- [ ] **Step 2: If failing, fix and rerun**
+
+- [ ] **Step 3: Hand off to `finishing-a-development-branch` workflow**
+
+---
+
+## Skills During Execution
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `superpowers:receiving-code-review` (if review feedback arrives)
+- `superpowers:finishing-a-development-branch` (after tasks complete)
+
+## Commit Strategy
+- One commit per task (or smaller, if needed for clarity).
+- Keep commits scoped and imperative.

--- a/docs/superpowers/specs/2026-03-28-chaos-actions-phase-2a-admin-toggles-design.md
+++ b/docs/superpowers/specs/2026-03-28-chaos-actions-phase-2a-admin-toggles-design.md
@@ -1,0 +1,95 @@
+# ChaosDonkey Phase 2A Design: Admin Action Toggles
+
+Date: 2026-03-28
+Scope: Admin UX/config for per-action enable/disable toggles only
+
+## Goal
+Allow administrators to enable/disable each chaos action from Magento admin config, with runtime behavior that avoids selecting disabled actions.
+
+## Architecture
+Keep current action framework (`ActionPool`, resolver, action classes) unchanged.
+
+Implement config-driven runtime gating in `chaosdonkey:kick` by filtering eligible outcomes before final execution:
+1. Read action toggle config values.
+2. Roll D20 and resolve outcome.
+3. If resolved action is disabled, reroll until outcome is executable (enabled action or non-action outcome).
+4. Execute final outcome and persist final state.
+
+This preserves existing boundaries and minimizes risk.
+
+## Admin Config Model
+Add three new toggles under `admin/chaos_donkey`:
+- `enable_reindex_all`
+- `enable_cache_flush`
+- `enable_graphql_pipeline_stress`
+
+Defaults in `etc/config.xml`:
+- all three toggles enabled (`1`)
+
+## Components
+### `etc/adminhtml/system.xml`
+Add yes/no fields for per-action toggles.
+
+### `etc/config.xml`
+Add default values for new toggle keys.
+
+### `Model/Config.php`
+Add constants/getters:
+- `CONFIG_PATH_ENABLE_REINDEX_ALL`
+- `CONFIG_PATH_ENABLE_CACHE_FLUSH`
+- `CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS`
+
+Add helper:
+- `isActionEnabled(string $actionCode): bool`
+
+### `Console/Command/ChaosDonkeyKick.php`
+Update outcome-selection flow:
+- precompute enabled action set
+- roll/resolve loop with max-attempt guard
+- skip disabled action outcomes by rerolling
+- execute only valid final outcome
+- persist final roll and final outcome
+
+## Data Flow
+1. Check module enabled (`admin/chaos_donkey/enabled`).
+2. Build enabled-action map from new toggles.
+3. Roll D20.
+4. Resolve outcome code.
+5. If outcome is disabled action, reroll (bounded loop).
+6. Execute final outcome (action or message outcome).
+7. Persist final `last_run`, `last_kick`, `last_outcome`.
+
+## Edge Behavior
+### All actions disabled
+- Command logs warning:
+  - `All configured chaos actions are disabled. Rolling non-action outcomes only.`
+- Only non-action outcomes are eligible.
+- No action execution attempted.
+
+### Max-attempt guard reached
+- Fallback to `napping`.
+- Log warning about max reroll attempts.
+
+## Testing Strategy
+### Unit tests
+- `Model/ConfigTest.php`
+  - new getters
+  - `isActionEnabled()` mapping behavior
+
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+  - enabled action executes normally
+  - disabled action triggers reroll
+  - all-actions-disabled warning appears
+  - max-attempt guard falls back to `napping`
+
+### Regression verification
+- run full suite: `vendor/bin/phpunit`
+
+## Out of Scope
+- probability tuning
+- admin GraphQL query builder/templates
+- per-store overrides
+- cron automation
+
+## Recommendation
+Ship Phase 2A as minimal config/runtime gating with reroll behavior and clear operator logs, then move to Phase 2B for probability controls and advanced admin UX.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -9,6 +9,18 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_reindex_all" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Reindex All</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="enable_cache_flush" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable Cache Flush</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="enable_graphql_pipeline_stress" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Enable GraphQL Pipeline Stress</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -9,15 +9,15 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_reindex_all" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_reindex_all" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enable Reindex All</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_cache_flush" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_cache_flush" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enable Cache Flush</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="enable_graphql_pipeline_stress" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_graphql_pipeline_stress" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Enable GraphQL Pipeline Stress</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,6 +5,9 @@
         <admin>
             <chaos_donkey>
                 <enabled>0</enabled>
+                <enable_reindex_all>1</enable_reindex_all>
+                <enable_cache_flush>1</enable_cache_flush>
+                <enable_graphql_pipeline_stress>1</enable_graphql_pipeline_stress>
             </chaos_donkey>
         </admin>
     </default>

--- a/scripts/pr-finish.sh
+++ b/scripts/pr-finish.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required." >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required." >&2
+  exit 1
+fi
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: scripts/pr-finish.sh [base-branch]" >&2
+  exit 1
+fi
+
+base_branch="${1:-main}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+gh pr merge --squash --delete-branch --auto
+
+git switch "$base_branch"
+git pull --ff-only origin "$base_branch"

--- a/scripts/pr-start.sh
+++ b/scripts/pr-start.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI (gh) is required." >&2
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "Error: git is required." >&2
+  exit 1
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: scripts/pr-start.sh <feature-branch> [base-branch]" >&2
+  exit 1
+fi
+
+branch_name="$1"
+base_branch="${2:-main}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: working tree has staged or unstaged tracked changes. Commit or stash first." >&2
+  exit 1
+fi
+
+if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
+  echo "Error: branch '$branch_name' already exists." >&2
+  exit 1
+fi
+
+git switch "$base_branch"
+git pull --ff-only origin "$base_branch"
+git switch -c "$branch_name"
+git push -u origin HEAD
+
+gh pr create --fill


### PR DESCRIPTION
@codex

## Summary
- add Phase 2A admin toggles for chaos actions (`reindex_all`, `cache_flush`, `graphql_pipeline_stress`)
- add config defaults and `Config` accessors/mapping for action enablement
- update `chaosdonkey:kick` to reroll disabled action outcomes (bounded), warn once when all actions are disabled, and fall back to `napping` on guard exhaustion
- update unit tests for config mapping and kick-command reroll behavior
- document toggle/reroll behavior in README

## Validation
- `vendor/bin/phpunit`
- Result: `OK (36 tests, 2271 assertions)`