### PR TITLE
@codex Phase 2B: cron automation with shared kick executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@
 /.phpunit.cache/
 /.worktrees/
 /AGENTS.md
+/tmp/

--- a/Console/Command/ChaosDonkeyKick.php
+++ b/Console/Command/ChaosDonkeyKick.php
@@ -3,43 +3,24 @@ declare(strict_types = 1);
 
 namespace ShaunMcManus\ChaosDonkey\Console\Command;
 
-use ShaunMcManus\ChaosDonkey\Model\ActionPool;
 use ShaunMcManus\ChaosDonkey\Model\Config;
-use ShaunMcManus\ChaosDonkey\Model\KickRoller;
-use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
-use ShaunMcManus\ChaosDonkey\Model\StateWriter;
+use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ChaosDonkeyKick extends Command
 {
-    private const MAX_REROLL_ATTEMPTS = 20;
-    private const ACTION_CODES = [
-        'reindex_all',
-        'cache_flush',
-        'graphql_pipeline_stress',
-    ];
-
     private Config $config;
-    private ActionPool $actionPool;
-    private RollOutcomeResolver $resolver;
-    private StateWriter $stateWriter;
-    private KickRoller $kickRoller;
+    private KickExecutor $kickExecutor;
 
     public function __construct(
         Config $config,
-        ActionPool $actionPool,
-        RollOutcomeResolver $resolver,
-        StateWriter $stateWriter,
-        KickRoller $kickRoller
+        KickExecutor $kickExecutor
     ) {
         parent::__construct();
         $this->config = $config;
-        $this->actionPool = $actionPool;
-        $this->resolver = $resolver;
-        $this->stateWriter = $stateWriter;
-        $this->kickRoller = $kickRoller;
+        $this->kickExecutor = $kickExecutor;
     }
 
     /**
@@ -64,73 +45,12 @@ class ChaosDonkeyKick extends Command
             return Command::SUCCESS;
         }
 
-        $enabledActions = $this->getEnabledActions();
-        if (!in_array(true, $enabledActions, true)) {
-            $output->writeln('All configured chaos actions are disabled. Rolling non-action outcomes only.');
+        $result = $this->kickExecutor->execute();
+
+        foreach ($result['messages'] as $message) {
+            $output->writeln($message);
         }
-
-        $kick = 0;
-        $outcome = 'napping';
-
-        for ($attempt = 0; $attempt < self::MAX_REROLL_ATTEMPTS; $attempt++) {
-            $kick = $this->kickRoller->rollD20();
-            $outcome = $this->resolver->resolve($kick);
-
-            if (!$this->isDisabledActionOutcome($outcome, $enabledActions)) {
-                break;
-            }
-        }
-
-        if ($this->isDisabledActionOutcome($outcome, $enabledActions)) {
-            $outcome = 'napping';
-            $output->writeln('Max reroll attempts reached. Falling back to napping.');
-        }
-
-        $output->writeln('ChaosDonkeyKick kicks your Magento. You rolled a ' . $kick);
-
-        $action = $this->actionPool->get($outcome);
-        if ($action !== null) {
-            $result = $action->execute($output);
-            $output->writeln($result->getSummary());
-        } else {
-            match ($outcome) {
-                'critical_failure' => $output->writeln('Critical Failure! Better check all of your donkeys.'),
-                'critical_success' => $output->writeln('Critical Success! Yee Haw the donkeys are loose!'),
-                'napping' => $output->writeln('The donkeys are napping'),
-                default => $output->writeln('Unknown chaos outcome. The donkeys stare suspiciously.'),
-            };
-        }
-
-        $this->stateWriter->saveLastRun((new \DateTimeImmutable())->format(DATE_ATOM));
-        $this->stateWriter->saveLastKick($kick);
-        $this->stateWriter->saveLastOutcome($outcome);
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @return array<string, bool>
-     */
-    private function getEnabledActions(): array
-    {
-        $enabledActions = [];
-
-        foreach (self::ACTION_CODES as $actionCode) {
-            $enabledActions[$actionCode] = $this->config->isActionEnabled($actionCode);
-        }
-
-        return $enabledActions;
-    }
-
-    /**
-     * @param array<string, bool> $enabledActions
-     */
-    private function isDisabledActionOutcome(string $outcome, array $enabledActions): bool
-    {
-        if (!array_key_exists($outcome, $enabledActions)) {
-            return false;
-        }
-
-        return $enabledActions[$outcome] === false;
     }
 }

--- a/Cron/ChaosDonkeyKickCron.php
+++ b/Cron/ChaosDonkeyKickCron.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace ShaunMcManus\ChaosDonkey\Cron;
 
+use Psr\Log\LoggerInterface;
 use ShaunMcManus\ChaosDonkey\Model\Config;
 use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
 
@@ -10,7 +11,8 @@ class ChaosDonkeyKickCron
 {
     public function __construct(
         private Config $config,
-        private KickExecutor $kickExecutor
+        private KickExecutor $kickExecutor,
+        private LoggerInterface $logger
     ) {
     }
 
@@ -26,6 +28,13 @@ class ChaosDonkeyKickCron
 
         if (!$this->config->isCronEnabled()) {
             $this->logMessage('Skipping ChaosDonkey cron because cron execution is disabled.');
+
+            return;
+        }
+
+        $cronExpression = $this->config->getCronExpression();
+        if (!$this->isValidCronExpression($cronExpression)) {
+            $this->logMessage('Skipping ChaosDonkey cron because cron_expression is invalid.');
 
             return;
         }
@@ -65,8 +74,28 @@ class ChaosDonkeyKickCron
         return (int) (new \DateTimeImmutable())->format('G');
     }
 
+    protected function isValidCronExpression(?string $cronExpression): bool
+    {
+        if ($cronExpression === null) {
+            return false;
+        }
+
+        $fields = preg_split('/\s+/', trim($cronExpression));
+        if (!is_array($fields) || count($fields) !== 5) {
+            return false;
+        }
+
+        foreach ($fields as $field) {
+            if ($field === '' || preg_match('/^[\d*\/,\-]+$/', $field) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     protected function logMessage(string $message): void
     {
-        error_log('[ChaosDonkey] ' . $message);
+        $this->logger->info('[ChaosDonkey] ' . $message);
     }
 }

--- a/Cron/ChaosDonkeyKickCron.php
+++ b/Cron/ChaosDonkeyKickCron.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Cron;
+
+use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
+
+class ChaosDonkeyKickCron
+{
+    public function __construct(
+        private Config $config,
+        private KickExecutor $kickExecutor
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $this->logMessage('ChaosDonkey cron started.');
+
+        if (!$this->config->isEnabled()) {
+            $this->logMessage('Skipping ChaosDonkey cron because the module is disabled.');
+
+            return;
+        }
+
+        if (!$this->config->isCronEnabled()) {
+            $this->logMessage('Skipping ChaosDonkey cron because cron execution is disabled.');
+
+            return;
+        }
+
+        $allowedHoursRaw = $this->config->getCronAllowedHoursRaw();
+        $allowedHours = $this->config->getCronAllowedHours();
+
+        if ($allowedHoursRaw !== null && $allowedHours === []) {
+            $this->logMessage('Skipping ChaosDonkey cron because cron_allowed_hours is invalid.');
+
+            return;
+        }
+
+        $currentHour = $this->getCurrentHour();
+        if ($allowedHours !== [] && !in_array($currentHour, $allowedHours, true)) {
+            $this->logMessage(sprintf(
+                'Skipping ChaosDonkey cron because current hour %d is not in the allowed window.',
+                $currentHour
+            ));
+
+            return;
+        }
+
+        $this->logMessage(sprintf('Executing ChaosDonkey cron at hour %d.', $currentHour));
+
+        $result = $this->kickExecutor->execute();
+
+        $this->logMessage(sprintf(
+            'ChaosDonkey cron completed with kick %d and outcome %s.',
+            $result['kick'],
+            $result['outcome']
+        ));
+    }
+
+    protected function getCurrentHour(): int
+    {
+        return (int) (new \DateTimeImmutable())->format('G');
+    }
+
+    protected function logMessage(string $message): void
+    {
+        error_log('[ChaosDonkey] ' . $message);
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -12,6 +12,9 @@ class Config
     public const CONFIG_PATH_ENABLE_REINDEX_ALL = 'admin/chaos_donkey/enable_reindex_all';
     public const CONFIG_PATH_ENABLE_CACHE_FLUSH = 'admin/chaos_donkey/enable_cache_flush';
     public const CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS = 'admin/chaos_donkey/enable_graphql_pipeline_stress';
+    public const CONFIG_PATH_CRON_ENABLED = 'admin/chaos_donkey/cron_enabled';
+    public const CONFIG_PATH_CRON_EXPRESSION = 'admin/chaos_donkey/cron_expression';
+    public const CONFIG_PATH_CRON_ALLOWED_HOURS = 'admin/chaos_donkey/cron_allowed_hours';
     public const CONFIG_PATH_LAST_RUN = 'admin/chaos_donkey/last_run';
     public const CONFIG_PATH_LAST_KICK = 'admin/chaos_donkey/last_kick';
     public const CONFIG_PATH_LAST_OUTCOME = 'admin/chaos_donkey/last_outcome';
@@ -45,6 +48,70 @@ class Config
     public function isGraphQlPipelineStressEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
     {
         return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS, $scopeType, $scopeCode);
+    }
+
+    public function isCronEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_CRON_ENABLED, $scopeType, $scopeCode);
+    }
+
+    public function getCronExpression(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): ?string
+    {
+        $value = $this->scopeConfig->getValue(self::CONFIG_PATH_CRON_EXPRESSION, $scopeType, $scopeCode);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $normalizedValue = trim((string) $value);
+
+        return $normalizedValue === '' ? null : $normalizedValue;
+    }
+
+    public function getCronAllowedHoursRaw(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): ?string
+    {
+        $value = $this->scopeConfig->getValue(self::CONFIG_PATH_CRON_ALLOWED_HOURS, $scopeType, $scopeCode);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $normalizedValue = trim((string) $value);
+
+        return $normalizedValue === '' ? null : $normalizedValue;
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getCronAllowedHours(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): array
+    {
+        $rawValue = $this->getCronAllowedHoursRaw($scopeType, $scopeCode);
+        if ($rawValue === null) {
+            return [];
+        }
+
+        $allowedHours = [];
+
+        foreach (explode(',', $rawValue) as $token) {
+            $normalizedToken = trim($token);
+
+            if ($normalizedToken === '' || !ctype_digit($normalizedToken)) {
+                continue;
+            }
+
+            $hour = (int) $normalizedToken;
+            if ($hour < 0 || $hour > 23) {
+                continue;
+            }
+
+            $allowedHours[] = $hour;
+        }
+
+        $allowedHours = array_values(array_unique($allowedHours));
+        sort($allowedHours);
+
+        return $allowedHours;
     }
 
     public function isActionEnabled(string $actionCode): bool

--- a/Model/KickExecutor.php
+++ b/Model/KickExecutor.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model;
+
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class KickExecutor
+{
+    private const MAX_REROLL_ATTEMPTS = 20;
+    private const ACTION_CODES = [
+        'reindex_all',
+        'cache_flush',
+        'graphql_pipeline_stress',
+    ];
+
+    public function __construct(
+        private Config $config,
+        private ActionPool $actionPool,
+        private RollOutcomeResolver $resolver,
+        private StateWriter $stateWriter,
+        private KickRoller $kickRoller
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     kick: int,
+     *     outcome: string,
+     *     messages: list<string>
+     * }
+     */
+    public function execute(): array
+    {
+        $messages = [];
+        $enabledActions = $this->getEnabledActions();
+
+        if (!in_array(true, $enabledActions, true)) {
+            $messages[] = 'All configured chaos actions are disabled. Rolling non-action outcomes only.';
+        }
+
+        $kick = 0;
+        $outcome = 'napping';
+
+        for ($attempt = 0; $attempt < self::MAX_REROLL_ATTEMPTS; $attempt++) {
+            $kick = $this->kickRoller->rollD20();
+            $outcome = $this->resolver->resolve($kick);
+
+            if (!$this->isDisabledActionOutcome($outcome, $enabledActions)) {
+                break;
+            }
+        }
+
+        if ($this->isDisabledActionOutcome($outcome, $enabledActions)) {
+            $outcome = 'napping';
+            $messages[] = 'Max reroll attempts reached. Falling back to napping.';
+        }
+
+        $messages[] = 'ChaosDonkeyKick kicks your Magento. You rolled a ' . $kick;
+
+        $action = $this->actionPool->get($outcome);
+        if ($action !== null) {
+            $buffer = new BufferedOutput();
+            $result = $action->execute($buffer);
+            $bufferedOutput = trim($buffer->fetch());
+
+            if ($bufferedOutput !== '') {
+                foreach (preg_split('/\r\n|\r|\n/', $bufferedOutput) as $line) {
+                    $messages[] = $line;
+                }
+            }
+
+            $messages[] = $result->getSummary();
+        } else {
+            match ($outcome) {
+                'critical_failure' => $messages[] = 'Critical Failure! Better check all of your donkeys.',
+                'critical_success' => $messages[] = 'Critical Success! Yee Haw the donkeys are loose!',
+                'napping' => $messages[] = 'The donkeys are napping',
+                default => $messages[] = 'Unknown chaos outcome. The donkeys stare suspiciously.',
+            };
+        }
+
+        $this->stateWriter->saveLastRun((new \DateTimeImmutable())->format(DATE_ATOM));
+        $this->stateWriter->saveLastKick($kick);
+        $this->stateWriter->saveLastOutcome($outcome);
+
+        return [
+            'kick' => $kick,
+            'outcome' => $outcome,
+            'messages' => $messages,
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function getEnabledActions(): array
+    {
+        $enabledActions = [];
+
+        foreach (self::ACTION_CODES as $actionCode) {
+            $enabledActions[$actionCode] = $this->config->isActionEnabled($actionCode);
+        }
+
+        return $enabledActions;
+    }
+
+    /**
+     * @param array<string, bool> $enabledActions
+     */
+    private function isDisabledActionOutcome(string $outcome, array $enabledActions): bool
+    {
+        if (!array_key_exists($outcome, $enabledActions)) {
+            return false;
+        }
+
+        return $enabledActions[$outcome] === false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ Current outcome mapping:
 
 For action outcomes, `chaosdonkey:kick` resolves an action code and executes a DI-wired action service from the action pool.
 
+## Cron Automation
+
+ChaosDonkey can also run on Magento cron using the same kick execution pipeline as the CLI command.
+
+Cron settings live under `admin/chaos_donkey`:
+- `admin/chaos_donkey/cron_enabled`
+- `admin/chaos_donkey/cron_expression`
+- `admin/chaos_donkey/cron_allowed_hours`
+
+Magento reads the schedule expression from `admin/chaos_donkey/cron_expression` for the cron job definition.
+
+`admin/chaos_donkey/cron_allowed_hours` accepts comma-separated hour values from `0` to `23`.
+Examples:
+- `1,2,3`
+- `0, 12, 23`
+- empty value means no hour restriction
+
+Cron execution skips when:
+- the module is disabled
+- cron execution is disabled
+- `cron_allowed_hours` is invalid
+- the current hour is outside the allowed window
+
+When it does run, cron delegates to the same kick execution pipeline as `chaosdonkey:kick`, so rerolls, action toggles, and state persistence behave the same way.
+
 ### `bin/magento chaosdonkey:status`
 Prints real module status values from config/state:
 - Enabled (`Yes`/`No`)

--- a/Test/Stubs/Psr/Log/LoggerInterface.php
+++ b/Test/Stubs/Psr/Log/LoggerInterface.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Psr\Log;
+
+interface LoggerInterface
+{
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function emergency($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function alert($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function critical($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function error($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function warning($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function notice($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function info($message, array $context = []): void;
+
+    /**
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function debug($message, array $context = []): void;
+
+    /**
+     * @param mixed $level
+     * @param mixed $message
+     * @param array<mixed> $context
+     */
+    public function log($level, $message, array $context = []): void;
+}

--- a/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
@@ -5,45 +5,28 @@ namespace ShaunMcManus\ChaosDonkey\Test\Unit\Console\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
 use ShaunMcManus\ChaosDonkey\Console\Command\ChaosDonkeyKick;
-use ShaunMcManus\ChaosDonkey\Model\ActionPool;
-use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use ShaunMcManus\ChaosDonkey\Model\Config;
-use ShaunMcManus\ChaosDonkey\Model\KickRoller;
-use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
-use ShaunMcManus\ChaosDonkey\Model\StateWriter;
+use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ChaosDonkeyKickTest extends TestCase
 {
     private Config&MockObject $config;
-    private ActionPool&MockObject $actionPool;
-    private RollOutcomeResolver&MockObject $resolver;
-    private StateWriter&MockObject $stateWriter;
-    private KickRoller&MockObject $kickRoller;
+    private KickExecutor&MockObject $kickExecutor;
 
     protected function setUp(): void
     {
         $this->config = $this->createMock(Config::class);
-        $this->actionPool = $this->createMock(ActionPool::class);
-        $this->resolver = $this->createMock(RollOutcomeResolver::class);
-        $this->stateWriter = $this->createMock(StateWriter::class);
-        $this->kickRoller = $this->createMock(KickRoller::class);
+        $this->kickExecutor = $this->createMock(KickExecutor::class);
     }
 
     public function testItExitsEarlyWhenDisabled(): void
     {
         $this->config->expects(self::once())->method('isEnabled')->willReturn(false);
+        $this->kickExecutor->expects(self::never())->method('execute');
 
-        $this->kickRoller->expects(self::never())->method('rollD20');
-        $this->resolver->expects(self::never())->method('resolve');
-        $this->actionPool->expects(self::never())->method('get');
-        $this->stateWriter->expects(self::never())->method('saveLastRun');
-        $this->stateWriter->expects(self::never())->method('saveLastKick');
-        $this->stateWriter->expects(self::never())->method('saveLastOutcome');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->kickExecutor);
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([]);
@@ -52,229 +35,30 @@ class ChaosDonkeyKickTest extends TestCase
         self::assertStringContainsString('ChaosDonkey is disabled', $tester->getDisplay());
     }
 
-    public function testRollOneSavesStateAndPrintsCriticalFailure(): void
+    public function testItDelegatesEnabledExecutionAndPrintsReturnedMessages(): void
     {
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(1);
-        $this->resolver->expects(self::once())->method('resolve')->with(1)->willReturn('critical_failure');
-        $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
-
-        $this->stateWriter
+        $this->kickExecutor
             ->expects(self::once())
-            ->method('saveLastRun')
-            ->with(self::callback(static function (string $timestamp): bool {
-                $parsed = \DateTimeImmutable::createFromFormat(DATE_ATOM, $timestamp);
-
-                return $parsed !== false && $parsed->format(DATE_ATOM) === $timestamp;
-            }));
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(1);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('You rolled a 1', $tester->getDisplay());
-        self::assertStringContainsString('Critical Failure!', $tester->getDisplay());
-    }
-
-    public function testRollThreeTriggersMappedAction(): void
-    {
-        $action = $this->createStub(ChaosActionInterface::class);
-        $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'ok'));
-
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->config->method('isActionEnabled')->willReturn(true);
-        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
-        $this->resolver->expects(self::once())->method('resolve')->with(3)->willReturn('cache_flush');
-        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('You rolled a 3', $tester->getDisplay());
-    }
-
-    public function testRollFourTriggersMappedAction(): void
-    {
-        $action = $this->createStub(ChaosActionInterface::class);
-        $action->method('execute')->willReturn(new ChaosActionResult('graphql_pipeline_stress', 'ok'));
-
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->config->method('isActionEnabled')->willReturn(true);
-        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(4);
-        $this->resolver->expects(self::once())->method('resolve')->with(4)->willReturn('graphql_pipeline_stress');
-        $this->actionPool->expects(self::once())->method('get')->with('graphql_pipeline_stress')->willReturn($action);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(4);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('graphql_pipeline_stress');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('You rolled a 4', $tester->getDisplay());
-    }
-
-    public function testRollTwentySavesStateAndPrintsCriticalSuccess(): void
-    {
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(20);
-        $this->resolver->expects(self::once())->method('resolve')->with(20)->willReturn('critical_success');
-        $this->actionPool->expects(self::once())->method('get')->with('critical_success')->willReturn(null);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(20);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_success');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('You rolled a 20', $tester->getDisplay());
-        self::assertStringContainsString('Critical Success!', $tester->getDisplay());
-    }
-
-    public function testDefaultRollSavesStateAndPrintsNappingMessage(): void
-    {
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(6);
-        $this->resolver->expects(self::once())->method('resolve')->with(6)->willReturn('napping');
-        $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(6);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('You rolled a 6', $tester->getDisplay());
-        self::assertStringContainsString('The donkeys are napping', $tester->getDisplay());
-    }
-
-    public function testDisabledActionOutcomeTriggersRerollAndPersistsFinalOutcome(): void
-    {
-        $action = $this->createStub(ChaosActionInterface::class);
-        $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'ok'));
-
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->config->expects(self::exactly(3))
-            ->method('isActionEnabled')
-            ->willReturnMap([
-                ['reindex_all', false],
-                ['cache_flush', true],
-                ['graphql_pipeline_stress', true],
+            ->method('execute')
+            ->willReturn([
+                'kick' => 3,
+                'outcome' => 'cache_flush',
+                'messages' => [
+                    'ChaosDonkeyKick kicks your Magento. You rolled a 3',
+                    'Cache flush started',
+                    'Cache flush completed',
+                ],
             ]);
-        $this->kickRoller->expects(self::exactly(2))
-            ->method('rollD20')
-            ->willReturnOnConsecutiveCalls(2, 3);
-        $resolvedRolls = [];
-        $this->resolver->expects(self::exactly(2))
-            ->method('resolve')
-            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
-                $resolvedRolls[] = $kick;
 
-                return match ($kick) {
-                    2 => 'reindex_all',
-                    3 => 'cache_flush',
-                };
-            });
-        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $command = new ChaosDonkeyKick($this->config, $this->kickExecutor);
         $tester = new CommandTester($command);
 
-        $tester->execute([]);
+        $exitCode = $tester->execute([]);
 
-        self::assertSame([2, 3], $resolvedRolls);
-        self::assertStringContainsString('You rolled a 3', $tester->getDisplay());
-        self::assertStringNotContainsString('You rolled a 2', $tester->getDisplay());
-    }
-
-    public function testAllActionsDisabledWarnsOnceAndExecutesOnlyNonActionOutcome(): void
-    {
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->config->expects(self::exactly(3))
-            ->method('isActionEnabled')
-            ->willReturn(false);
-        $this->kickRoller->expects(self::exactly(4))
-            ->method('rollD20')
-            ->willReturnOnConsecutiveCalls(2, 3, 4, 1);
-        $resolvedRolls = [];
-        $this->resolver->expects(self::exactly(4))
-            ->method('resolve')
-            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
-                $resolvedRolls[] = $kick;
-
-                return match ($kick) {
-                    1 => 'critical_failure',
-                    2 => 'reindex_all',
-                    3 => 'cache_flush',
-                    4 => 'graphql_pipeline_stress',
-                };
-            });
-        $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(1);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertSame([2, 3, 4, 1], $resolvedRolls);
-        self::assertSame(
-            1,
-            substr_count($tester->getDisplay(), 'All configured chaos actions are disabled. Rolling non-action outcomes only.')
-        );
-        self::assertStringContainsString('You rolled a 1', $tester->getDisplay());
-        self::assertStringContainsString('Critical Failure!', $tester->getDisplay());
-    }
-
-    public function testMaxAttemptGuardFallsBackToNapping(): void
-    {
-        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
-        $this->config->expects(self::exactly(3))
-            ->method('isActionEnabled')
-            ->willReturnMap([
-                ['reindex_all', false],
-                ['cache_flush', true],
-                ['graphql_pipeline_stress', true],
-            ]);
-        $this->kickRoller->expects(self::exactly(20))->method('rollD20')->willReturn(2);
-        $this->resolver->expects(self::exactly(20))->method('resolve')->with(2)->willReturn('reindex_all');
-        $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
-
-        $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(2);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
-
-        $command = new ChaosDonkeyKick($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
-        $tester = new CommandTester($command);
-
-        $tester->execute([]);
-
-        self::assertStringContainsString('Max reroll attempts reached. Falling back to napping.', $tester->getDisplay());
-        self::assertStringContainsString('You rolled a 2', $tester->getDisplay());
-        self::assertStringContainsString('The donkeys are napping', $tester->getDisplay());
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('ChaosDonkeyKick kicks your Magento. You rolled a 3', $tester->getDisplay());
+        self::assertStringContainsString('Cache flush started', $tester->getDisplay());
+        self::assertStringContainsString('Cache flush completed', $tester->getDisplay());
     }
 }

--- a/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
+++ b/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
@@ -1,0 +1,147 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Cron;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Cron\ChaosDonkeyKickCron;
+use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
+
+class ChaosDonkeyKickCronTest extends TestCase
+{
+    private Config&MockObject $config;
+    private KickExecutor&MockObject $kickExecutor;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->kickExecutor = $this->createMock(KickExecutor::class);
+    }
+
+    public function testItSkipsWhenModuleDisabled(): void
+    {
+        $cron = $this->createCron(12);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(false);
+        $this->config->expects(self::never())->method('isCronEnabled');
+        $this->kickExecutor->expects(self::never())->method('execute');
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Skipping ChaosDonkey cron because the module is disabled.',
+        ], $cron->messages);
+    }
+
+    public function testItSkipsWhenCronDisabled(): void
+    {
+        $cron = $this->createCron(12);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(false);
+        $this->kickExecutor->expects(self::never())->method('execute');
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Skipping ChaosDonkey cron because cron execution is disabled.',
+        ], $cron->messages);
+    }
+
+    public function testItSkipsOutsideAllowedHours(): void
+    {
+        $cron = $this->createCron(9);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor->expects(self::never())->method('execute');
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Skipping ChaosDonkey cron because current hour 9 is not in the allowed window.',
+        ], $cron->messages);
+    }
+
+    public function testItExecutesWhenEnabledAndInsideAllowedHours(): void
+    {
+        $cron = $this->createCron(5);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'napping',
+                'messages' => ['ChaosDonkeyKick kicks your Magento. You rolled a 5', 'The donkeys are napping'],
+            ]);
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Executing ChaosDonkey cron at hour 5.',
+            'ChaosDonkey cron completed with kick 5 and outcome napping.',
+        ], $cron->messages);
+    }
+
+    public function testItSkipsWhenAllowedHoursConfigIsInvalid(): void
+    {
+        $cron = $this->createCron(8);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('foo, 99');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([]);
+        $this->kickExecutor->expects(self::never())->method('execute');
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Skipping ChaosDonkey cron because cron_allowed_hours is invalid.',
+        ], $cron->messages);
+    }
+
+    private function createCron(int $currentHour): TestCronHarness
+    {
+        return new TestCronHarness($this->config, $this->kickExecutor, $currentHour);
+    }
+}
+
+class TestCronHarness extends ChaosDonkeyKickCron
+{
+    /**
+     * @var list<string>
+     */
+    public array $messages = [];
+
+    public function __construct(
+        Config $config,
+        KickExecutor $kickExecutor,
+        private int $currentHour
+    ) {
+        parent::__construct($config, $kickExecutor);
+    }
+
+    protected function getCurrentHour(): int
+    {
+        return $this->currentHour;
+    }
+
+    protected function logMessage(string $message): void
+    {
+        $this->messages[] = $message;
+    }
+}

--- a/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
+++ b/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
@@ -5,6 +5,7 @@ namespace ShaunMcManus\ChaosDonkey\Test\Unit\Cron;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use ShaunMcManus\ChaosDonkey\Cron\ChaosDonkeyKickCron;
 use ShaunMcManus\ChaosDonkey\Model\Config;
 use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
@@ -13,11 +14,13 @@ class ChaosDonkeyKickCronTest extends TestCase
 {
     private Config&MockObject $config;
     private KickExecutor&MockObject $kickExecutor;
+    private LoggerInterface $logger;
 
     protected function setUp(): void
     {
         $this->config = $this->createMock(Config::class);
         $this->kickExecutor = $this->createMock(KickExecutor::class);
+        $this->logger = new NullLoggerStub();
     }
 
     public function testItSkipsWhenModuleDisabled(): void
@@ -26,6 +29,7 @@ class ChaosDonkeyKickCronTest extends TestCase
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(false);
         $this->config->expects(self::never())->method('isCronEnabled');
+        $this->config->expects(self::never())->method('getCronExpression');
         $this->kickExecutor->expects(self::never())->method('execute');
 
         $cron->execute();
@@ -42,6 +46,7 @@ class ChaosDonkeyKickCronTest extends TestCase
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
         $this->config->expects(self::once())->method('isCronEnabled')->willReturn(false);
+        $this->config->expects(self::never())->method('getCronExpression');
         $this->kickExecutor->expects(self::never())->method('execute');
 
         $cron->execute();
@@ -58,6 +63,7 @@ class ChaosDonkeyKickCronTest extends TestCase
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
         $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
         $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
         $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
         $this->kickExecutor->expects(self::never())->method('execute');
@@ -76,6 +82,7 @@ class ChaosDonkeyKickCronTest extends TestCase
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
         $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
         $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
         $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
         $this->kickExecutor
@@ -102,6 +109,7 @@ class ChaosDonkeyKickCronTest extends TestCase
 
         $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
         $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
         $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('foo, 99');
         $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([]);
         $this->kickExecutor->expects(self::never())->method('execute');
@@ -114,13 +122,32 @@ class ChaosDonkeyKickCronTest extends TestCase
         ], $cron->messages);
     }
 
-    private function createCron(int $currentHour): TestCronHarness
+    public function testItSkipsWhenCronExpressionIsInvalid(): void
     {
-        return new TestCronHarness($this->config, $this->kickExecutor, $currentHour);
+        $cron = $this->createCron(10);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('invalid cron');
+        $this->config->expects(self::never())->method('getCronAllowedHoursRaw');
+        $this->config->expects(self::never())->method('getCronAllowedHours');
+        $this->kickExecutor->expects(self::never())->method('execute');
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Skipping ChaosDonkey cron because cron_expression is invalid.',
+        ], $cron->messages);
+    }
+
+    private function createCron(int $currentHour): CronHarness
+    {
+        return new CronHarness($this->config, $this->kickExecutor, $this->logger, $currentHour);
     }
 }
 
-class TestCronHarness extends ChaosDonkeyKickCron
+class CronHarness extends ChaosDonkeyKickCron
 {
     /**
      * @var list<string>
@@ -130,9 +157,10 @@ class TestCronHarness extends ChaosDonkeyKickCron
     public function __construct(
         Config $config,
         KickExecutor $kickExecutor,
+        LoggerInterface $logger,
         private int $currentHour
     ) {
-        parent::__construct($config, $kickExecutor);
+        parent::__construct($config, $kickExecutor, $logger);
     }
 
     protected function getCurrentHour(): int
@@ -143,5 +171,44 @@ class TestCronHarness extends ChaosDonkeyKickCron
     protected function logMessage(string $message): void
     {
         $this->messages[] = $message;
+    }
+}
+
+class NullLoggerStub implements LoggerInterface
+{
+    public function emergency($message, array $context = []): void
+    {
+    }
+
+    public function alert($message, array $context = []): void
+    {
+    }
+
+    public function critical($message, array $context = []): void
+    {
+    }
+
+    public function error($message, array $context = []): void
+    {
+    }
+
+    public function warning($message, array $context = []): void
+    {
+    }
+
+    public function notice($message, array $context = []): void
+    {
+    }
+
+    public function info($message, array $context = []): void
+    {
+    }
+
+    public function debug($message, array $context = []): void
+    {
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
     }
 }

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -70,6 +70,110 @@ class ConfigTest extends TestCase
         self::assertTrue($config->isGraphQlPipelineStressEnabled());
     }
 
+    public function testItReadsCronEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_CRON_ENABLED, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isCronEnabled());
+    }
+
+    public function testItReadsTrimmedCronExpressionFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_EXPRESSION, 'default', null)
+            ->willReturn('  */30 * * * *  ');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertSame('*/30 * * * *', $config->getCronExpression());
+    }
+
+    public function testItTreatsEmptyCronExpressionAsUnset(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_EXPRESSION, 'default', null)
+            ->willReturn('   ');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertNull($config->getCronExpression());
+    }
+
+    public function testItReadsTrimmedCronAllowedHoursFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_ALLOWED_HOURS, 'default', null)
+            ->willReturn(' 1, 2, 3 ');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertSame('1, 2, 3', $config->getCronAllowedHoursRaw());
+    }
+
+    public function testItTreatsEmptyCronAllowedHoursAsUnset(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_ALLOWED_HOURS, 'default', null)
+            ->willReturn('   ');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertNull($config->getCronAllowedHoursRaw());
+    }
+
+    public function testItReturnsEmptyAllowedHoursWhenUnset(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_ALLOWED_HOURS, 'default', null)
+            ->willReturn(null);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertSame([], $config->getCronAllowedHours());
+    }
+
+    public function testItParsesAllowedHoursIntoUniqueSortedIntegers(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_ALLOWED_HOURS, 'default', null)
+            ->willReturn(' 5, 2, 5, 23, 0, 18 ');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertSame([0, 2, 5, 18, 23], $config->getCronAllowedHours());
+    }
+
+    public function testItIgnoresInvalidAllowedHourTokens(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('getValue')
+            ->with(Config::CONFIG_PATH_CRON_ALLOWED_HOURS, 'default', null)
+            ->willReturn('foo, -1, 24, 7, 03, 12bar, 8, , 11');
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertSame([3, 7, 8, 11], $config->getCronAllowedHours());
+    }
+
     public function testItReadsLastRunFromExpectedPath(): void
     {
         $this->scopeConfig

--- a/Test/Unit/Model/KickExecutorTest.php
+++ b/Test/Unit/Model/KickExecutorTest.php
@@ -1,0 +1,190 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ActionPool;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
+use ShaunMcManus\ChaosDonkey\Model\KickRoller;
+use ShaunMcManus\ChaosDonkey\Model\RollOutcomeResolver;
+use ShaunMcManus\ChaosDonkey\Model\StateWriter;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class KickExecutorTest extends TestCase
+{
+    private Config&MockObject $config;
+    private ActionPool&MockObject $actionPool;
+    private RollOutcomeResolver&MockObject $resolver;
+    private StateWriter&MockObject $stateWriter;
+    private KickRoller&MockObject $kickRoller;
+
+    protected function setUp(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $this->actionPool = $this->createMock(ActionPool::class);
+        $this->resolver = $this->createMock(RollOutcomeResolver::class);
+        $this->stateWriter = $this->createMock(StateWriter::class);
+        $this->kickRoller = $this->createMock(KickRoller::class);
+    }
+
+    public function testItExecutesMappedActionAndCapturesActionOutput(): void
+    {
+        $action = $this->createMock(ChaosActionInterface::class);
+        $action->expects(self::once())
+            ->method('execute')
+            ->willReturnCallback(static function (BufferedOutput $output): ChaosActionResult {
+                $output->writeln('Cache flush started');
+
+                return new ChaosActionResult('cache_flush', 'Cache flush completed');
+            });
+
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', true],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+            ]);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
+        $this->resolver->expects(self::once())->method('resolve')->with(3)->willReturn('cache_flush');
+        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun')
+            ->with(self::callback(static function (string $timestamp): bool {
+                $parsed = \DateTimeImmutable::createFromFormat(DATE_ATOM, $timestamp);
+
+                return $parsed !== false && $parsed->format(DATE_ATOM) === $timestamp;
+            }));
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
+
+        $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $result = $executor->execute();
+
+        self::assertSame(3, $result['kick']);
+        self::assertSame('cache_flush', $result['outcome']);
+        self::assertSame([
+            'ChaosDonkeyKick kicks your Magento. You rolled a 3',
+            'Cache flush started',
+            'Cache flush completed',
+        ], $result['messages']);
+    }
+
+    public function testItRerollsDisabledActionOutcomeAndPersistsFinalOutcome(): void
+    {
+        $action = $this->createStub(ChaosActionInterface::class);
+        $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'Cache flush completed'));
+
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', false],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+            ]);
+        $this->kickRoller->expects(self::exactly(2))
+            ->method('rollD20')
+            ->willReturnOnConsecutiveCalls(2, 3);
+        $resolvedRolls = [];
+        $this->resolver->expects(self::exactly(2))
+            ->method('resolve')
+            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
+                $resolvedRolls[] = $kick;
+
+                return match ($kick) {
+                    2 => 'reindex_all',
+                    3 => 'cache_flush',
+                };
+            });
+        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
+
+        $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $result = $executor->execute();
+
+        self::assertSame([2, 3], $resolvedRolls);
+        self::assertSame(3, $result['kick']);
+        self::assertSame('cache_flush', $result['outcome']);
+        self::assertSame([
+            'ChaosDonkeyKick kicks your Magento. You rolled a 3',
+            'Cache flush completed',
+        ], $result['messages']);
+    }
+
+    public function testItWarnsOnceWhenAllActionsDisabledAndExecutesNonActionOutcome(): void
+    {
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturn(false);
+        $this->kickRoller->expects(self::exactly(4))
+            ->method('rollD20')
+            ->willReturnOnConsecutiveCalls(2, 3, 4, 1);
+        $resolvedRolls = [];
+        $this->resolver->expects(self::exactly(4))
+            ->method('resolve')
+            ->willReturnCallback(static function (int $kick) use (&$resolvedRolls): string {
+                $resolvedRolls[] = $kick;
+
+                return match ($kick) {
+                    1 => 'critical_failure',
+                    2 => 'reindex_all',
+                    3 => 'cache_flush',
+                    4 => 'graphql_pipeline_stress',
+                };
+            });
+        $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(1);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
+
+        $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $result = $executor->execute();
+
+        self::assertSame([2, 3, 4, 1], $resolvedRolls);
+        self::assertSame(1, $result['kick']);
+        self::assertSame('critical_failure', $result['outcome']);
+        self::assertSame([
+            'All configured chaos actions are disabled. Rolling non-action outcomes only.',
+            'ChaosDonkeyKick kicks your Magento. You rolled a 1',
+            'Critical Failure! Better check all of your donkeys.',
+        ], $result['messages']);
+    }
+
+    public function testItFallsBackToNappingAfterMaxAttempts(): void
+    {
+        $this->config->expects(self::exactly(3))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', false],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+            ]);
+        $this->kickRoller->expects(self::exactly(20))->method('rollD20')->willReturn(2);
+        $this->resolver->expects(self::exactly(20))->method('resolve')->with(2)->willReturn('reindex_all');
+        $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(2);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
+
+        $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $result = $executor->execute();
+
+        self::assertSame(2, $result['kick']);
+        self::assertSame('napping', $result['outcome']);
+        self::assertSame([
+            'Max reroll attempts reached. Falling back to napping.',
+            'ChaosDonkeyKick kicks your Magento. You rolled a 2',
+            'The donkeys are napping',
+        ], $result['messages']);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
             "ShaunMcManus\\ChaosDonkey\\Test\\": "Test/",
             "Magento\\Framework\\": "Test/Stubs/Magento/Framework/",
             "Magento\\Indexer\\": "Test/Stubs/Magento/Indexer/",
-            "Magento\\Store\\": "Test/Stubs/Magento/Store/"
+            "Magento\\Store\\": "Test/Stubs/Magento/Store/",
+            "Psr\\Log\\": "Test/Stubs/Psr/Log/"
         }
     },
     "require-dev": {

--- a/docs/superpowers/plans/2026-03-29-chaos-actions-phase-2b-cron-automation-implementation-plan.md
+++ b/docs/superpowers/plans/2026-03-29-chaos-actions-phase-2b-cron-automation-implementation-plan.md
@@ -1,0 +1,247 @@
+# Chaos Actions Phase 2B Cron Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Magento-native cron automation for ChaosDonkey kicks with admin-configurable scheduling gates, while keeping kick behavior identical to CLI execution.
+
+**Architecture:** Introduce cron configuration keys and a cron entrypoint that delegates to a shared kick executor service. Refactor `chaosdonkey:kick` to call the same executor so CLI and cron use one orchestration path (including action-toggle reroll and state persistence).
+
+**Tech Stack:** PHP 8.5, Magento 2 config/cron XML, Symfony Console, PSR-3 logging, PHPUnit 12
+
+---
+
+## Scope and Boundaries
+- In scope: admin cron config fields/defaults, cron registration, shared executor extraction, cron gate checks (enabled + allowed hours), unit tests, README updates.
+- Out of scope: schedule preset builders, cron jitter, DB run history table, per-action schedules.
+
+## File Map
+
+### Create
+- `Cron/ChaosDonkeyKickCron.php`
+- `Model/KickExecutor.php`
+- `Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+- `Test/Unit/Model/KickExecutorTest.php`
+
+### Modify
+- `etc/adminhtml/system.xml`
+- `etc/config.xml`
+- `etc/crontab.xml` (new if absent in repo)
+- `etc/di.xml` (only if additional wiring is required)
+- `Model/Config.php`
+- `Console/Command/ChaosDonkeyKick.php`
+- `Test/Unit/Model/ConfigTest.php`
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+- `README.md`
+
+### Verify Existing
+- `Test/Unit/Action/*.php`
+- `Test/Unit/Console/Command/ChaosDonkeyStatusTest.php`
+
+---
+
+### Task 1: Add Cron Admin Config Fields and Defaults
+
+**Files:**
+- Modify: `etc/adminhtml/system.xml`
+- Modify: `etc/config.xml`
+
+- [ ] **Step 1: Add failing expectations in config tests (if applicable)**
+- Add assertions in config tests for new cron keys/default handling where practical.
+
+- [ ] **Step 2: Implement admin fields and defaults**
+- Add fields under `admin/chaos_donkey`:
+  - `cron_enabled` (yes/no)
+  - `cron_expression` (text)
+  - `cron_allowed_hours` (text)
+- Set defaults in `etc/config.xml`:
+  - `cron_enabled=0`
+  - `cron_expression=*/30 * * * *`
+  - `cron_allowed_hours=` (empty)
+- Use default scope only for these new fields.
+
+- [ ] **Step 3: Verify no regressions**
+Run: `vendor/bin/phpunit --filter ConfigTest`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+```bash
+git add etc/adminhtml/system.xml etc/config.xml Test/Unit/Model/ConfigTest.php
+git commit -m "Add cron admin config fields and defaults"
+```
+
+---
+
+### Task 2: Extend Config Model for Cron Accessors and Hour Parsing
+
+**Files:**
+- Modify: `Model/Config.php`
+- Modify: `Test/Unit/Model/ConfigTest.php`
+
+- [ ] **Step 1: Write failing tests**
+Add tests for:
+- `isCronEnabled()`
+- `getCronExpression()` trimming/normalization
+- `getCronAllowedHoursRaw()`
+- `getCronAllowedHours()` returning sorted unique `int[]`
+- invalid tokens handling strategy (ignore invalid entries, keep valid values)
+
+- [ ] **Step 2: Run RED**
+Run: `vendor/bin/phpunit Test/Unit/Model/ConfigTest.php`
+Expected: FAIL on missing methods/constants.
+
+- [ ] **Step 3: Implement minimal config logic**
+- Add config path constants.
+- Add cron getter methods.
+- Implement allowed-hours parser:
+  - split by comma
+  - trim tokens
+  - accept only numeric 0-23
+  - discard invalid tokens
+  - unique + sort ascending
+
+- [ ] **Step 4: Run GREEN**
+Run: `vendor/bin/phpunit Test/Unit/Model/ConfigTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add Model/Config.php Test/Unit/Model/ConfigTest.php
+git commit -m "Add cron config accessors and allowed-hour parsing"
+```
+
+---
+
+### Task 3: Extract Shared Kick Executor Service
+
+**Files:**
+- Create: `Model/KickExecutor.php`
+- Create: `Test/Unit/Model/KickExecutorTest.php`
+- Modify: `Console/Command/ChaosDonkeyKick.php`
+- Modify: `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+
+- [ ] **Step 1: Write failing executor tests**
+Cover existing kick behavior currently in command:
+- module disabled short-circuit behavior handled by caller contract
+- disabled-action reroll behavior
+- all-actions-disabled warning text hook
+- max-attempt fallback to `napping`
+- final state persistence
+
+- [ ] **Step 2: Run RED**
+Run: `vendor/bin/phpunit Test/Unit/Model/KickExecutorTest.php`
+Expected: FAIL (class missing).
+
+- [ ] **Step 3: Implement `KickExecutor`**
+- Move orchestration logic from command to executor.
+- Keep current result behavior unchanged.
+- Return a small result DTO/object for caller-specific output needs.
+
+- [ ] **Step 4: Refactor command to delegate**
+- Command keeps CLI formatting.
+- Command calls executor and prints returned messages.
+
+- [ ] **Step 5: Run focused GREEN**
+Run:
+- `vendor/bin/phpunit Test/Unit/Model/KickExecutorTest.php`
+- `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+```bash
+git add Model/KickExecutor.php Console/Command/ChaosDonkeyKick.php Test/Unit/Model/KickExecutorTest.php Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+git commit -m "Extract shared kick executor for CLI and cron"
+```
+
+---
+
+### Task 4: Add Magento Cron Wiring and Cron Job Class
+
+**Files:**
+- Create or Modify: `etc/crontab.xml`
+- Create: `Cron/ChaosDonkeyKickCron.php`
+- Create: `Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+- Modify: `etc/di.xml` (only if explicit wiring needed)
+
+- [ ] **Step 1: Write failing cron tests**
+Test cases:
+- skip when module disabled
+- skip when cron disabled
+- skip outside allowed hours
+- execute inside allowed hours
+- invalid allowed-hours input does not crash job
+
+- [ ] **Step 2: Run RED**
+Run: `vendor/bin/phpunit Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+Expected: FAIL (files missing).
+
+- [ ] **Step 3: Implement cron registration and class**
+- Add cron job ID and schedule config path usage.
+- Cron class dependencies: `Config`, `KickExecutor`, logger, clock/time provider.
+- Add explicit skip/execution logs.
+
+- [ ] **Step 4: Run GREEN**
+Run: `vendor/bin/phpunit Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add etc/crontab.xml Cron/ChaosDonkeyKickCron.php Test/Unit/Cron/ChaosDonkeyKickCronTest.php etc/di.xml
+git commit -m "Add Magento cron job for automated ChaosDonkey kicks"
+```
+
+---
+
+### Task 5: Documentation and Full Verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README**
+Document:
+- new cron admin config keys
+- sample cron expression usage
+- allowed-hours format
+- skip behavior when cron/module disabled
+
+- [ ] **Step 2: Run full suite**
+Run: `vendor/bin/phpunit`
+Expected: full PASS with no new failures.
+
+- [ ] **Step 3: Commit docs**
+```bash
+git add README.md
+git commit -m "Document Phase 2B cron automation settings"
+```
+
+---
+
+### Task 6: Final Verification Gate
+
+**Files:**
+- No code changes expected unless regression found
+
+- [ ] **Step 1: Final command set**
+```bash
+vendor/bin/phpunit
+git status --short
+```
+Expected:
+- tests green
+- clean tree (except intentional untracked files)
+
+- [ ] **Step 2: Resolve any failures and rerun**
+
+- [ ] **Step 3: Hand off to `finishing-a-development-branch` workflow**
+
+---
+
+## Skills During Execution
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `superpowers:receiving-code-review` (when feedback arrives)
+- `superpowers:finishing-a-development-branch` (after all tasks pass)
+
+## Commit Strategy
+- One commit per task for clean review.
+- Keep behavior-changing commits separate from docs-only commits.
+- Preserve green tests at each checkpoint.

--- a/docs/superpowers/specs/2026-03-29-chaos-actions-phase-2b-cron-automation-design.md
+++ b/docs/superpowers/specs/2026-03-29-chaos-actions-phase-2b-cron-automation-design.md
@@ -1,0 +1,107 @@
+# ChaosDonkey Phase 2B Design: Cron Automation
+
+Date: 2026-03-29
+Scope: Magento-native scheduled execution for ChaosDonkey kicks
+
+## Goal
+Allow ChaosDonkey kicks to run automatically on a configurable Magento cron schedule, with explicit admin gating and predictable operator logs.
+
+## Architecture
+Implement cron execution as a Magento-native cron job (`etc/crontab.xml` + cron class), not shelling out to `bin/magento`.
+
+To avoid duplicating logic between CLI and cron, extract shared kick execution into a reusable service (for example `Model/KickExecutor`).
+
+- `chaosdonkey:kick` command delegates to the shared executor.
+- Cron job delegates to the same executor.
+- Existing action toggles and reroll behavior remain the single source of truth.
+
+## Admin Config Model
+Add Phase 2B cron config under `admin/chaos_donkey`:
+
+- `cron_enabled` (yes/no, default `0`)
+- `cron_expression` (text, default `*/30 * * * *`)
+- `cron_allowed_hours` (text, optional, default empty)
+
+Scope policy for Phase 2B:
+- default scope only (`showInDefault=1`, website/store hidden)
+
+`cron_allowed_hours` format (v1):
+- comma-separated `0-23` integers, example: `1,2,3,22,23`
+- empty means "no hour restriction"
+
+## Components
+### `etc/adminhtml/system.xml`
+Add cron controls to the existing Chaos Donkey config group.
+
+### `etc/config.xml`
+Add default cron values.
+
+### `Model/Config.php`
+Add constants/getters for new cron keys:
+- `isCronEnabled()`
+- `getCronExpression()`
+- `getCronAllowedHoursRaw()`
+- `getCronAllowedHours(): array<int>` (normalized unique sorted values)
+
+### `etc/crontab.xml`
+Register scheduled cron job entry for ChaosDonkey.
+
+### `Cron/ChaosDonkeyKickCron.php`
+Cron entrypoint that:
+1. exits early when module disabled
+2. exits early when cron disabled
+3. exits early when current hour not in allowed set (if configured)
+4. invokes shared kick executor
+5. logs skip/execution outcomes to module logger context
+
+### Shared executor (`Model/KickExecutor.php`)
+Move command orchestration (roll, reroll disabled actions, action execution, state persistence) into a reusable class callable from CLI and cron.
+
+Command and cron should differ only in presentation context (console output vs logger).
+
+## Data Flow
+1. Magento cron triggers job by `cron_expression`.
+2. Cron job checks `isEnabled()` and `isCronEnabled()`.
+3. Cron job checks current server hour against parsed allowed-hours list.
+4. If allowed, invoke shared kick executor.
+5. Shared executor performs existing kick flow (including action toggle reroll behavior) and persists final state.
+
+## Error Handling and Guardrails
+- Invalid cron expression or invalid allowed-hours config must not crash cron processing.
+- On invalid config, skip execution and log a warning with path/key.
+- All skip reasons should be explicit:
+  - module disabled
+  - cron disabled
+  - outside allowed hours
+  - invalid cron config
+
+## Testing Strategy
+### Unit tests
+- `Model/ConfigTest.php`
+  - cron getters and allowed-hours normalization
+
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+  - command delegates to shared executor (after refactor)
+
+- `Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+  - skips when module disabled
+  - skips when cron disabled
+  - skips outside allowed hours
+  - executes when enabled and in allowed hours
+  - handles invalid allowed-hours config safely
+
+- `Test/Unit/Model/KickExecutorTest.php` (new)
+  - core kick orchestration behavior stays equivalent to existing behavior
+
+### Regression verification
+- full suite: `vendor/bin/phpunit`
+
+## Out of Scope
+- preset schedule builder UI
+- per-action time windows
+- randomized cron jitter
+- database-backed run history table
+- external scheduling services
+
+## Recommendation
+Ship Phase 2B with Magento-native cron wiring and shared kick execution service. This keeps behavior consistent across CLI and cron, aligns with Magento patterns, and sets up future admin UX improvements without rewiring runtime logic.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,6 +21,16 @@
                     <label>Enable GraphQL Pipeline Stress</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="cron_enabled" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Cron Enabled</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="cron_expression" translate="label" type="text" sortOrder="60" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Cron Expression</label>
+                </field>
+                <field id="cron_allowed_hours" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Cron Allowed Hours</label>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,9 @@
                 <enable_reindex_all>1</enable_reindex_all>
                 <enable_cache_flush>1</enable_cache_flush>
                 <enable_graphql_pipeline_stress>1</enable_graphql_pipeline_stress>
+                <cron_enabled>0</cron_enabled>
+                <cron_expression>*/30 * * * *</cron_expression>
+                <cron_allowed_hours></cron_allowed_hours>
             </chaos_donkey>
         </admin>
     </default>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="chaosdonkey_kick"
+             instance="ShaunMcManus\ChaosDonkey\Cron\ChaosDonkeyKickCron"
+             method="execute">
+            <config_path>admin/chaos_donkey/cron_expression</config_path>
+        </job>
+    </group>
+</config>


### PR DESCRIPTION
@codex

## Summary
- add Phase 2B cron automation with Magento-native cron wiring (`etc/crontab.xml`) using `admin/chaos_donkey/cron_expression`
- add cron admin settings:
  - `admin/chaos_donkey/cron_enabled`
  - `admin/chaos_donkey/cron_expression`
  - `admin/chaos_donkey/cron_allowed_hours`
- add cron config accessors/parsing in `Model/Config`
- extract shared kick orchestration to `Model/KickExecutor` so CLI + cron use one execution pipeline
- add `Cron/ChaosDonkeyKickCron` with gating for:
  - module enabled
  - cron enabled
  - valid cron expression
  - valid/allowed hour window
- switch cron logging to `Psr\Log\LoggerInterface` (replace direct `error_log`)
- expand unit coverage for config parsing, kick executor behavior, command delegation, and cron execution/skips
- update README with cron configuration and behavior

## Validation
- `vendor/bin/phpunit Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
  - `OK (6 tests, 18 assertions)`
- `vendor/bin/phpunit`
  - `OK (47 tests, 2293 assertions)`