### PR TITLE
Expand status command operator visibility

### DIFF
--- a/Action/CacheBackendHealthSnapshot.php
+++ b/Action/CacheBackendHealthSnapshot.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Action;
+
+use Magento\Framework\App\Cache\Frontend\Pool;
+use Magento\Framework\App\Cache\TypeListInterface;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeDetailRow;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeSnapshot;
+use Throwable;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CacheBackendHealthSnapshot implements ChaosActionInterface
+{
+    private const string UNKNOWN_SUMMARY = 'cache snapshot unavailable';
+
+    public function __construct(
+        private TypeListInterface $typeList,
+        private Pool $frontendPool,
+        private ProbeOutputFormatter $probeOutputFormatter,
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return 'cache_backend_health_snapshot';
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
+    {
+        $snapshot = $this->collectSnapshot();
+
+        $output->writeln($this->probeOutputFormatter->formatLines($snapshot));
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            '',
+            [],
+            $snapshot->getStatus() !== 'unknown'
+        );
+    }
+
+    private function collectSnapshot(): ProbeSnapshot
+    {
+        try {
+            $types = $this->typeList->getTypes();
+        } catch (Throwable $exception) {
+            return new ProbeSnapshot(
+                $this->getCode(),
+                'unknown',
+                self::UNKNOWN_SUMMARY,
+                [
+                    new ProbeDetailRow('cache', 'metadata', 'unknown', 'unavailable'),
+                ]
+            );
+        }
+
+        $details = [];
+        $enabledTypeCount = 0;
+
+        foreach ($types as $typeCode => $metadata) {
+            $isEnabled = isset($metadata['status']) && (int) $metadata['status'] === 1;
+            if ($isEnabled) {
+                $enabledTypeCount++;
+            }
+
+            $details[] = new ProbeDetailRow(
+                'cache',
+                (string) $typeCode,
+                'ok',
+                sprintf('enabled=%s', $isEnabled ? 'true' : 'false')
+            );
+        }
+
+        try {
+            $defaultFrontend = $this->frontendPool->get('default');
+        } catch (Throwable $exception) {
+            return $this->resolveBackendUnavailable($details);
+        }
+
+        if ($defaultFrontend === null) {
+            return $this->resolveBackendUnavailable($details);
+        }
+
+        try {
+            $backend = $defaultFrontend->getBackend();
+            $adapter = $this->sanitizeAdapterLabel(get_class($backend));
+
+            $details[] = new ProbeDetailRow('cache_backend', 'backend', 'ok', $adapter);
+
+            return new ProbeSnapshot(
+                $this->getCode(),
+                'ok',
+                sprintf(
+                    '%d cache types, %d enabled, backend adapter=%s',
+                    count($types),
+                    $enabledTypeCount,
+                    $adapter
+                ),
+                $details
+            );
+        } catch (Throwable $exception) {
+            $details[] = new ProbeDetailRow('cache_backend', 'backend', 'warn', 'resolution_failed');
+
+            return new ProbeSnapshot(
+                $this->getCode(),
+                'warn',
+                sprintf(
+                    '%d cache types, %d enabled, backend adapter resolution degraded',
+                    count($types),
+                    $enabledTypeCount
+                ),
+                $details
+            );
+        }
+    }
+
+    private function resolveBackendUnavailable(array $details): ProbeSnapshot
+    {
+        $details[] = new ProbeDetailRow('cache_backend', 'default_frontend', 'unknown', 'unavailable');
+        $details[] = new ProbeDetailRow('cache_backend', 'backend', 'unknown', 'unavailable');
+
+        return new ProbeSnapshot(
+            $this->getCode(),
+            'unknown',
+            self::UNKNOWN_SUMMARY,
+            $details
+        );
+    }
+
+    private function sanitizeAdapterLabel(string $adapterClass): string
+    {
+        $backslashPosition = strrpos($adapterClass, '\\');
+        $slashPosition = strrpos($adapterClass, '/');
+        $separator = max(
+            $backslashPosition === false ? -1 : $backslashPosition,
+            $slashPosition === false ? -1 : $slashPosition
+        );
+
+        if ($separator < 0) {
+            $basename = $adapterClass;
+        } else {
+            $basename = substr($adapterClass, $separator + 1);
+        }
+
+        $normalized = strtolower((string) $basename);
+        $normalized = preg_replace('/[^a-z0-9_]+/', '_', $normalized) ?: '';
+
+        return trim($normalized, '_') === '' ? 'unavailable' : trim($normalized, '_');
+    }
+}

--- a/Action/CacheBackendHealthSnapshot.php
+++ b/Action/CacheBackendHealthSnapshot.php
@@ -89,7 +89,7 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
             $backend = $defaultFrontend->getBackend();
             $adapter = $this->sanitizeAdapterLabel(get_class($backend));
 
-            $details[] = new ProbeDetailRow('cache_backend', 'backend', 'ok', $adapter);
+            $details[] = new ProbeDetailRow('cache_backend', 'default_frontend', 'ok', $adapter);
 
             return new ProbeSnapshot(
                 $this->getCode(),
@@ -103,7 +103,7 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
                 $details
             );
         } catch (Throwable $exception) {
-            $details[] = new ProbeDetailRow('cache_backend', 'backend', 'warn', 'resolution_failed');
+            $details[] = new ProbeDetailRow('cache_backend', 'default_frontend', 'warn', 'resolution_failed');
 
             return new ProbeSnapshot(
                 $this->getCode(),
@@ -121,8 +121,6 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
     private function resolveBackendUnavailable(array $details): ProbeSnapshot
     {
         $details[] = new ProbeDetailRow('cache_backend', 'default_frontend', 'unknown', 'unavailable');
-        $details[] = new ProbeDetailRow('cache_backend', 'backend', 'unknown', 'unavailable');
-
         return new ProbeSnapshot(
             $this->getCode(),
             'unknown',

--- a/Action/CacheBackendHealthSnapshot.php
+++ b/Action/CacheBackendHealthSnapshot.php
@@ -62,7 +62,7 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
         $enabledTypeCount = 0;
 
         foreach ($types as $typeCode => $metadata) {
-            $isEnabled = isset($metadata['status']) && (int) $metadata['status'] === 1;
+            $isEnabled = $this->isEnabledFromMetadata($metadata);
             if ($isEnabled) {
                 $enabledTypeCount++;
             }
@@ -91,10 +91,10 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
 
             $details[] = new ProbeDetailRow('cache_backend', 'default_frontend', 'ok', $adapter);
 
-            return new ProbeSnapshot(
-                $this->getCode(),
-                'ok',
-                sprintf(
+        return new ProbeSnapshot(
+            $this->getCode(),
+            'ok',
+            sprintf(
                     '%d cache types, %d enabled, backend adapter=%s',
                     count($types),
                     $enabledTypeCount,
@@ -127,6 +127,15 @@ class CacheBackendHealthSnapshot implements ChaosActionInterface
             self::UNKNOWN_SUMMARY,
             $details
         );
+    }
+
+    private function isEnabledFromMetadata(mixed $metadata): bool
+    {
+        if (!is_array($metadata) || !array_key_exists('status', $metadata)) {
+            return false;
+        }
+
+        return (int) $metadata['status'] === 1;
     }
 
     private function sanitizeAdapterLabel(string $adapterClass): string

--- a/Action/CacheBackendHealthSnapshot.php
+++ b/Action/CacheBackendHealthSnapshot.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CacheBackendHealthSnapshot implements ChaosActionInterface
 {
-    private const string UNKNOWN_SUMMARY = 'cache snapshot unavailable';
+    private const UNKNOWN_SUMMARY = 'cache snapshot unavailable';
 
     public function __construct(
         private TypeListInterface $typeList,

--- a/Action/CronQueueHealthSnapshot.php
+++ b/Action/CronQueueHealthSnapshot.php
@@ -1,0 +1,282 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Action;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ClockInterface;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeDetailRow;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeSnapshot;
+use Throwable;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CronQueueHealthSnapshot implements ChaosActionInterface
+{
+    private const string CODE = 'cron_queue_health_snapshot';
+
+    public function __construct(
+        private ResourceConnection $resourceConnection,
+        private ClockInterface $clock,
+        private ProbeOutputFormatter $probeOutputFormatter
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return self::CODE;
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
+    {
+        $snapshot = $this->collectSnapshot();
+
+        $output->writeln($this->probeOutputFormatter->formatLines($snapshot));
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            '',
+            [],
+            $snapshot->getStatus() !== 'unknown'
+        );
+    }
+
+    private function collectSnapshot(): ProbeSnapshot
+    {
+        try {
+            /** @var AdapterInterface $adapter */
+            $adapter = $this->resourceConnection->getConnection();
+        } catch (Throwable $exception) {
+            return new ProbeSnapshot(
+                $this->getCode(),
+                'unknown',
+                'cron=unknown, queue=unknown, failures_last_60m=n/a, pending_older_15m=n/a, activity_last_60m=n/a',
+                [
+                    new ProbeDetailRow('cron', 'failures_last_60m', 'unknown', 'n/a'),
+                    new ProbeDetailRow('cron', 'pending_older_15m', 'unknown', 'n/a'),
+                    new ProbeDetailRow('queue', 'tables_present', 'unknown', 'n/a'),
+                    new ProbeDetailRow('queue', 'activity_last_60m', 'unknown', 'n/a'),
+                ],
+                true
+            );
+        }
+
+        $nowUtc = $this->clock->nowUtc();
+        $lookback60m = $nowUtc->modify('-60 minutes');
+        $lookback15m = $nowUtc->modify('-15 minutes');
+        $lookback60mForQuery = $lookback60m->format('Y-m-d H:i:s');
+        $lookback15mForQuery = $lookback15m->format('Y-m-d H:i:s');
+
+        $cronSnapshot = $this->collectCronSnapshot(
+            $adapter,
+            $lookback60mForQuery,
+            $lookback15mForQuery
+        );
+
+        $queueSnapshot = $this->collectQueueSnapshot(
+            $adapter,
+            $lookback60mForQuery,
+            $cronSnapshot['status']
+        );
+
+        $overallStatus = $this->resolveOverallStatus(
+            $cronSnapshot['status'],
+            $queueSnapshot['status']
+        );
+
+        $summary = sprintf(
+            'cron=%s, queue=%s, failures_last_60m=%s, pending_older_15m=%s, activity_last_60m=%s',
+            $this->statusHeadline($cronSnapshot['status']),
+            $this->statusHeadline($queueSnapshot['status']),
+            $cronSnapshot['failures_last_60m'],
+            $cronSnapshot['pending_older_15m'],
+            $queueSnapshot['activity_last_60m']
+        );
+
+        return new ProbeSnapshot(
+            $this->getCode(),
+            $overallStatus,
+            $summary,
+            [
+                new ProbeDetailRow(
+                    'cron',
+                    'failures_last_60m',
+                    $cronSnapshot['status'],
+                    $cronSnapshot['failures_last_60m']
+                ),
+                new ProbeDetailRow(
+                    'cron',
+                    'pending_older_15m',
+                    $cronSnapshot['status'],
+                    $cronSnapshot['pending_older_15m']
+                ),
+                new ProbeDetailRow(
+                    'queue',
+                    'tables_present',
+                    $queueSnapshot['tables_present_status'],
+                    $queueSnapshot['tables_present']
+                ),
+                new ProbeDetailRow(
+                    'queue',
+                    'activity_last_60m',
+                    $queueSnapshot['activity_status'],
+                    $queueSnapshot['activity_last_60m']
+                ),
+            ],
+            true
+        );
+    }
+
+    /**
+     * @return array{status: string, failures_last_60m: string, pending_older_15m: string}
+     */
+    private function collectCronSnapshot(
+        AdapterInterface $adapter,
+        string $lookback60m,
+        string $lookback15m
+    ): array {
+        $cronTable = $this->resourceConnection->getTableName('cron_schedule');
+
+        try {
+            if (!$adapter->isTableExists($cronTable)) {
+                return [
+                    'status' => 'unknown',
+                    'failures_last_60m' => 'n/a',
+                    'pending_older_15m' => 'n/a',
+                ];
+            }
+
+            $failures = $this->fetchCount(
+                $adapter,
+                sprintf(
+                    'SELECT COUNT(*) FROM %s WHERE status IN (\'error\', \'missed\') AND scheduled_at >= :lookback_60m',
+                    $cronTable
+                ),
+                ['lookback_60m' => $lookback60m]
+            );
+
+            $pending = $this->fetchCount(
+                $adapter,
+                sprintf(
+                    'SELECT COUNT(*) FROM %s WHERE status = \'pending\' AND scheduled_at < :lookback_15m',
+                    $cronTable
+                ),
+                ['lookback_15m' => $lookback15m]
+            );
+
+            return [
+                'status' => ($failures > 0 || $pending > 10) ? 'warn' : 'ok',
+                'failures_last_60m' => (string) $failures,
+                'pending_older_15m' => (string) $pending,
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'status' => 'unknown',
+                'failures_last_60m' => 'n/a',
+                'pending_older_15m' => 'n/a',
+            ];
+        }
+    }
+
+    /**
+     * @return array{
+     *     status: string,
+     *     tables_present_status: string,
+     *     tables_present: string,
+     *     activity_status: string,
+     *     activity_last_60m: string
+     * }
+     */
+    private function collectQueueSnapshot(
+        AdapterInterface $adapter,
+        string $lookback60m,
+        string $cronStatus
+    ): array {
+        $queueTable = $this->resourceConnection->getTableName('queue');
+        $queueMessageTable = $this->resourceConnection->getTableName('queue_message');
+        $queueMessageStatusTable = $this->resourceConnection->getTableName('queue_message_status');
+
+        if (
+            !$adapter->isTableExists($queueTable)
+            || !$adapter->isTableExists($queueMessageTable)
+            || !$adapter->isTableExists($queueMessageStatusTable)
+        ) {
+            return [
+                'status' => 'unavailable',
+                'tables_present_status' => 'unavailable',
+                'tables_present' => 'false',
+                'activity_status' => 'unavailable',
+                'activity_last_60m' => 'n/a',
+            ];
+        }
+
+        try {
+            $activityCount = $this->fetchCount(
+                $adapter,
+                sprintf(
+                    'SELECT COUNT(*) FROM %s WHERE updated_at >= :lookback_60m',
+                    $queueMessageStatusTable
+                ),
+                ['lookback_60m' => $lookback60m]
+            );
+
+            return [
+                'status' => ($activityCount === 0 && $cronStatus === 'warn') ? 'warn' : 'ok',
+                'tables_present_status' => 'ok',
+                'tables_present' => 'true',
+                'activity_status' => ($activityCount === 0 && $cronStatus === 'warn') ? 'warn' : 'ok',
+                'activity_last_60m' => (string) $activityCount,
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'status' => 'unknown',
+                'tables_present_status' => 'ok',
+                'tables_present' => 'true',
+                'activity_status' => 'unknown',
+                'activity_last_60m' => 'n/a',
+            ];
+        }
+    }
+
+    private function fetchCount(AdapterInterface $adapter, string $sql, array $bind): int
+    {
+        $value = $adapter->fetchOne($sql, $bind);
+
+        if (is_numeric((string) $value)) {
+            return (int) $value;
+        }
+
+        return 0;
+    }
+
+    private function resolveOverallStatus(string $cronStatus, string $queueStatus): string
+    {
+        if ($cronStatus === 'warn' || $queueStatus === 'warn') {
+            return 'warn';
+        }
+
+        if ($cronStatus === 'unknown' || $queueStatus === 'unknown') {
+            return 'unknown';
+        }
+
+        if ($cronStatus === 'ok' && $queueStatus === 'unavailable') {
+            return 'ok';
+        }
+
+        return 'ok';
+    }
+
+    private function statusHeadline(string $status): string
+    {
+        return match ($status) {
+            'ok' => 'healthy',
+            'warn' => 'degraded',
+            'unavailable' => 'unavailable',
+            default => 'unknown',
+        };
+    }
+
+}

--- a/Action/CronQueueHealthSnapshot.php
+++ b/Action/CronQueueHealthSnapshot.php
@@ -57,7 +57,7 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
                 [
                     new ProbeDetailRow('cron', 'failures_last_60m', 'unknown', 'n/a'),
                     new ProbeDetailRow('cron', 'pending_older_15m', 'unknown', 'n/a'),
-                    new ProbeDetailRow('queue', 'tables_present', 'unknown', 'n/a'),
+                    new ProbeDetailRow('queue', 'tables_present', 'unavailable', 'false'),
                     new ProbeDetailRow('queue', 'activity_last_60m', 'unknown', 'n/a'),
                 ],
                 true
@@ -258,8 +258,8 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
         } catch (Throwable $exception) {
             return [
                 'status' => 'unknown',
-                'tables_present_status' => 'unknown',
-                'tables_present' => 'n/a',
+                'tables_present_status' => 'unavailable',
+                'tables_present' => 'false',
                 'activity_status' => 'unknown',
                 'activity_last_60m' => 'n/a',
             ];

--- a/Action/CronQueueHealthSnapshot.php
+++ b/Action/CronQueueHealthSnapshot.php
@@ -229,14 +229,24 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
                 ];
             }
 
-            $activityCount = $this->fetchCount(
-                $adapter,
-                sprintf(
-                    'SELECT COUNT(*) FROM %s WHERE updated_at >= :lookback_60m',
-                    $queueMessageStatusTable
-                ),
-                ['lookback_60m' => $lookback60m]
-            );
+            try {
+                $activityCount = $this->fetchCount(
+                    $adapter,
+                    sprintf(
+                        'SELECT COUNT(*) FROM %s WHERE updated_at >= :lookback_60m',
+                        $queueMessageStatusTable
+                    ),
+                    ['lookback_60m' => $lookback60m]
+                );
+            } catch (Throwable $exception) {
+                return [
+                    'status' => 'unknown',
+                    'tables_present_status' => 'ok',
+                    'tables_present' => 'true',
+                    'activity_status' => 'unknown',
+                    'activity_last_60m' => 'n/a',
+                ];
+            }
 
             return [
                 'status' => ($activityCount === 0 && $cronStatus === 'warn') ? 'warn' : 'ok',

--- a/Action/CronQueueHealthSnapshot.php
+++ b/Action/CronQueueHealthSnapshot.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CronQueueHealthSnapshot implements ChaosActionInterface
 {
-    private const string CODE = 'cron_queue_health_snapshot';
+    private const CODE = 'cron_queue_health_snapshot';
 
     public function __construct(
         private ResourceConnection $resourceConnection,

--- a/Action/CronQueueHealthSnapshot.php
+++ b/Action/CronQueueHealthSnapshot.php
@@ -104,13 +104,13 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
                 new ProbeDetailRow(
                     'cron',
                     'failures_last_60m',
-                    $cronSnapshot['status'],
+                    $cronSnapshot['failures_status'],
                     $cronSnapshot['failures_last_60m']
                 ),
                 new ProbeDetailRow(
                     'cron',
                     'pending_older_15m',
-                    $cronSnapshot['status'],
+                    $cronSnapshot['pending_status'],
                     $cronSnapshot['pending_older_15m']
                 ),
                 new ProbeDetailRow(
@@ -131,19 +131,27 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
     }
 
     /**
-     * @return array{status: string, failures_last_60m: string, pending_older_15m: string}
+     * @return array{
+     *     status: string,
+     *     failures_status: string,
+     *     pending_status: string,
+     *     failures_last_60m: string,
+     *     pending_older_15m: string
+     * }
      */
     private function collectCronSnapshot(
         AdapterInterface $adapter,
         string $lookback60m,
         string $lookback15m
     ): array {
-        $cronTable = $this->resourceConnection->getTableName('cron_schedule');
-
         try {
+            $cronTable = $this->resourceConnection->getTableName('cron_schedule');
+
             if (!$adapter->isTableExists($cronTable)) {
                 return [
                     'status' => 'unknown',
+                    'failures_status' => 'unknown',
+                    'pending_status' => 'unknown',
                     'failures_last_60m' => 'n/a',
                     'pending_older_15m' => 'n/a',
                 ];
@@ -167,14 +175,21 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
                 ['lookback_15m' => $lookback15m]
             );
 
+            $failuresStatus = ($failures > 0) ? 'warn' : 'ok';
+            $pendingStatus = ($pending > 10) ? 'warn' : 'ok';
+
             return [
-                'status' => ($failures > 0 || $pending > 10) ? 'warn' : 'ok',
+                'status' => ($failuresStatus === 'warn' || $pendingStatus === 'warn') ? 'warn' : 'ok',
+                'failures_status' => $failuresStatus,
+                'pending_status' => $pendingStatus,
                 'failures_last_60m' => (string) $failures,
                 'pending_older_15m' => (string) $pending,
             ];
         } catch (Throwable $exception) {
             return [
                 'status' => 'unknown',
+                'failures_status' => 'unknown',
+                'pending_status' => 'unknown',
                 'failures_last_60m' => 'n/a',
                 'pending_older_15m' => 'n/a',
             ];
@@ -195,25 +210,25 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
         string $lookback60m,
         string $cronStatus
     ): array {
-        $queueTable = $this->resourceConnection->getTableName('queue');
-        $queueMessageTable = $this->resourceConnection->getTableName('queue_message');
-        $queueMessageStatusTable = $this->resourceConnection->getTableName('queue_message_status');
-
-        if (
-            !$adapter->isTableExists($queueTable)
-            || !$adapter->isTableExists($queueMessageTable)
-            || !$adapter->isTableExists($queueMessageStatusTable)
-        ) {
-            return [
-                'status' => 'unavailable',
-                'tables_present_status' => 'unavailable',
-                'tables_present' => 'false',
-                'activity_status' => 'unavailable',
-                'activity_last_60m' => 'n/a',
-            ];
-        }
-
         try {
+            $queueTable = $this->resourceConnection->getTableName('queue');
+            $queueMessageTable = $this->resourceConnection->getTableName('queue_message');
+            $queueMessageStatusTable = $this->resourceConnection->getTableName('queue_message_status');
+
+            if (
+                !$adapter->isTableExists($queueTable)
+                || !$adapter->isTableExists($queueMessageTable)
+                || !$adapter->isTableExists($queueMessageStatusTable)
+            ) {
+                return [
+                    'status' => 'unavailable',
+                    'tables_present_status' => 'unavailable',
+                    'tables_present' => 'false',
+                    'activity_status' => 'unavailable',
+                    'activity_last_60m' => 'n/a',
+                ];
+            }
+
             $activityCount = $this->fetchCount(
                 $adapter,
                 sprintf(
@@ -233,8 +248,8 @@ class CronQueueHealthSnapshot implements ChaosActionInterface
         } catch (Throwable $exception) {
             return [
                 'status' => 'unknown',
-                'tables_present_status' => 'ok',
-                'tables_present' => 'true',
+                'tables_present_status' => 'unknown',
+                'tables_present' => 'n/a',
                 'activity_status' => 'unknown',
                 'activity_last_60m' => 'n/a',
             ];

--- a/Action/IndexerStatusSnapshot.php
+++ b/Action/IndexerStatusSnapshot.php
@@ -133,10 +133,10 @@ class IndexerStatusSnapshot implements ChaosActionInterface
         }
 
         $overallStatus = 'ok';
-        if ($unavailableStateCount > 0) {
-            $overallStatus = 'unknown';
-        } elseif ($needsReindex > 0) {
+        if ($needsReindex > 0) {
             $overallStatus = 'warn';
+        } elseif ($unavailableStateCount > 0) {
+            $overallStatus = 'unknown';
         } elseif ($unavailableModeCount > 0) {
             $overallStatus = 'unknown';
         }

--- a/Action/IndexerStatusSnapshot.php
+++ b/Action/IndexerStatusSnapshot.php
@@ -61,10 +61,27 @@ class IndexerStatusSnapshot implements ChaosActionInterface
         $needsReindex = 0;
         $unavailableModeCount = 0;
         $unavailableStateCount = 0;
+        $scheduledModeCount = 0;
+        $realtimeModeCount = 0;
 
         foreach ($indexers as $indexer) {
-            $indexerId = (string) $indexer->getId();
             $indexerCount++;
+
+            $indexerId = 'indexer';
+
+            try {
+                $indexerId = (string) $indexer->getId();
+            } catch (Throwable $exception) {
+                $unavailableStateCount++;
+                $details[] = new ProbeDetailRow(
+                    'indexer',
+                    'enumeration',
+                    'unknown',
+                    'unavailable'
+                );
+
+                continue;
+            }
 
             $state = 'unavailable';
             $mode = 'unavailable';
@@ -93,6 +110,10 @@ class IndexerStatusSnapshot implements ChaosActionInterface
 
             if ($mode === 'unavailable') {
                 $unavailableModeCount++;
+            } elseif ($mode === 'schedule') {
+                $scheduledModeCount++;
+            } else {
+                $realtimeModeCount++;
             }
 
             if ($state === 'unavailable') {
@@ -123,15 +144,27 @@ class IndexerStatusSnapshot implements ChaosActionInterface
             $overallStatus = 'unknown';
         }
 
+        $summary = sprintf(
+            '%d indexers, %d need reindex, modes=%s',
+            $indexerCount,
+            $needsReindex,
+            'unavailable'
+        );
+
+        if ($unavailableStateCount === 0 && $unavailableModeCount === 0) {
+            $summary = sprintf(
+                '%d indexers, %d need reindex, modes: schedule=%d, realtime=%d',
+                $indexerCount,
+                $needsReindex,
+                $scheduledModeCount,
+                $realtimeModeCount
+            );
+        }
+
         return new ProbeSnapshot(
             $this->getCode(),
             $overallStatus,
-            sprintf(
-                '%d indexers, %d need reindex, modes=%s',
-                $indexerCount,
-                $needsReindex,
-                $unavailableStateCount > 0 || $unavailableModeCount > 0 ? 'unavailable' : 'ok'
-            ),
+            $summary,
             $details
         );
     }

--- a/Action/IndexerStatusSnapshot.php
+++ b/Action/IndexerStatusSnapshot.php
@@ -46,14 +46,7 @@ class IndexerStatusSnapshot implements ChaosActionInterface
         try {
             $indexers = $this->collectionFactory->create();
         } catch (Throwable $exception) {
-            return new ProbeSnapshot(
-                $this->getCode(),
-                'unknown',
-                'n/a indexers, n/a need reindex, modes=unavailable',
-                [
-                    new ProbeDetailRow('indexer', 'enumeration', 'unknown', 'unavailable'),
-                ]
-            );
+            return $this->createEnumerationFailureSnapshot();
         }
 
         $details = [];
@@ -64,75 +57,79 @@ class IndexerStatusSnapshot implements ChaosActionInterface
         $scheduledModeCount = 0;
         $realtimeModeCount = 0;
 
-        foreach ($indexers as $indexer) {
-            $indexerCount++;
+        try {
+            foreach ($indexers as $indexer) {
+                $indexerCount++;
 
-            $indexerId = 'indexer';
-
-            try {
-                $indexerId = (string) $indexer->getId();
-            } catch (Throwable $exception) {
-                $unavailableStateCount++;
-                $details[] = new ProbeDetailRow(
-                    'indexer',
-                    'enumeration',
-                    'unknown',
-                    'unavailable'
-                );
-
-                continue;
-            }
-
-            $state = 'unavailable';
-            $mode = 'unavailable';
-            $detailStatus = 'unknown';
-
-            try {
-                $registryIndexer = $this->indexerRegistry->get($indexerId);
+                $indexerId = 'indexer';
 
                 try {
-                    $state = (string) $registryIndexer->getStatus();
+                    $indexerId = (string) $indexer->getId();
+                } catch (Throwable $exception) {
+                    $unavailableStateCount++;
+                    $details[] = new ProbeDetailRow(
+                        'indexer',
+                        'enumeration',
+                        'unknown',
+                        'unavailable'
+                    );
+
+                    continue;
+                }
+
+                $state = 'unavailable';
+                $mode = 'unavailable';
+                $detailStatus = 'unknown';
+
+                try {
+                    $registryIndexer = $this->indexerRegistry->get($indexerId);
+
+                    try {
+                        $state = (string) $registryIndexer->getStatus();
+                    } catch (Throwable $exception) {
+                        $state = 'unavailable';
+                        $unavailableStateCount++;
+                    }
+
+                    try {
+                        $mode = $registryIndexer->isScheduled() ? 'schedule' : 'realtime';
+                    } catch (Throwable $exception) {
+                        $mode = 'unavailable';
+                    }
                 } catch (Throwable $exception) {
                     $state = 'unavailable';
+                    $mode = 'unavailable';
                     $unavailableStateCount++;
                 }
 
-                try {
-                    $mode = $registryIndexer->isScheduled() ? 'schedule' : 'realtime';
-                } catch (Throwable $exception) {
-                    $mode = 'unavailable';
+                if ($mode === 'unavailable') {
+                    $unavailableModeCount++;
+                } elseif ($mode === 'schedule') {
+                    $scheduledModeCount++;
+                } else {
+                    $realtimeModeCount++;
                 }
-            } catch (Throwable $exception) {
-                $state = 'unavailable';
-                $mode = 'unavailable';
-                $unavailableStateCount++;
-            }
 
-            if ($mode === 'unavailable') {
-                $unavailableModeCount++;
-            } elseif ($mode === 'schedule') {
-                $scheduledModeCount++;
-            } else {
-                $realtimeModeCount++;
-            }
+                if ($state === 'unavailable') {
+                    $detailStatus = 'unknown';
+                } elseif ($this->requiresReindex($state)) {
+                    $detailStatus = 'warn';
+                    $needsReindex++;
+                } elseif ($mode === 'unavailable') {
+                    $detailStatus = 'unknown';
+                } else {
+                    $detailStatus = 'ok';
+                }
 
-            if ($state === 'unavailable') {
-                $detailStatus = 'unknown';
-            } elseif ($this->requiresReindex($state)) {
-                $detailStatus = 'warn';
-                $needsReindex++;
-            } elseif ($mode === 'unavailable') {
-                $detailStatus = 'unknown';
-            } else {
-                $detailStatus = 'ok';
+                $details[] = new ProbeDetailRow(
+                    'indexer',
+                    $indexerId,
+                    $detailStatus,
+                    sprintf('state=%s;mode=%s', $state, $mode)
+                );
             }
-
-            $details[] = new ProbeDetailRow(
-                'indexer',
-                $indexerId,
-                $detailStatus,
-                sprintf('state=%s;mode=%s', $state, $mode)
-            );
+        } catch (Throwable $exception) {
+            return $this->createEnumerationFailureSnapshot();
         }
 
         $overallStatus = 'ok';
@@ -172,5 +169,17 @@ class IndexerStatusSnapshot implements ChaosActionInterface
     private function requiresReindex(string $state): bool
     {
         return in_array(strtolower((string) $state), ['invalid', 'reindex-required', 'reindex_required'], true);
+    }
+
+    private function createEnumerationFailureSnapshot(): ProbeSnapshot
+    {
+        return new ProbeSnapshot(
+            $this->getCode(),
+            'unknown',
+            'n/a indexers, n/a need reindex, modes=unavailable',
+            [
+                new ProbeDetailRow('indexer', 'enumeration', 'unknown', 'unavailable'),
+            ]
+        );
     }
 }

--- a/Action/IndexerStatusSnapshot.php
+++ b/Action/IndexerStatusSnapshot.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Action;
+
+use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Magento\Indexer\Model\IndexerRegistry;
+use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
+use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeDetailRow;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeSnapshot;
+use Throwable;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class IndexerStatusSnapshot implements ChaosActionInterface
+{
+    public function __construct(
+        private CollectionFactory $collectionFactory,
+        private IndexerRegistry $indexerRegistry,
+        private ProbeOutputFormatter $probeOutputFormatter
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return 'indexer_status_snapshot';
+    }
+
+    public function execute(OutputInterface $output): ChaosActionResult
+    {
+        $snapshot = $this->snapshotStatuses();
+
+        $output->writeln($this->probeOutputFormatter->formatLines($snapshot));
+
+        return new ChaosActionResult(
+            $this->getCode(),
+            '',
+            [],
+            $snapshot->getStatus() !== 'unknown'
+        );
+    }
+
+    private function snapshotStatuses(): ProbeSnapshot
+    {
+        try {
+            $indexers = $this->collectionFactory->create();
+        } catch (Throwable $exception) {
+            return new ProbeSnapshot(
+                $this->getCode(),
+                'unknown',
+                'n/a indexers, n/a need reindex, modes=unavailable',
+                [
+                    new ProbeDetailRow('indexer', 'enumeration', 'unknown', 'unavailable'),
+                ]
+            );
+        }
+
+        $details = [];
+        $indexerCount = 0;
+        $needsReindex = 0;
+        $unavailableModeCount = 0;
+        $unavailableStateCount = 0;
+
+        foreach ($indexers as $indexer) {
+            $indexerId = (string) $indexer->getId();
+            $indexerCount++;
+
+            $state = 'unavailable';
+            $mode = 'unavailable';
+            $detailStatus = 'unknown';
+
+            try {
+                $registryIndexer = $this->indexerRegistry->get($indexerId);
+
+                try {
+                    $state = (string) $registryIndexer->getStatus();
+                } catch (Throwable $exception) {
+                    $state = 'unavailable';
+                    $unavailableStateCount++;
+                }
+
+                try {
+                    $mode = $registryIndexer->isScheduled() ? 'schedule' : 'realtime';
+                } catch (Throwable $exception) {
+                    $mode = 'unavailable';
+                }
+            } catch (Throwable $exception) {
+                $state = 'unavailable';
+                $mode = 'unavailable';
+                $unavailableStateCount++;
+            }
+
+            if ($mode === 'unavailable') {
+                $unavailableModeCount++;
+            }
+
+            if ($state === 'unavailable') {
+                $detailStatus = 'unknown';
+            } elseif ($this->requiresReindex($state)) {
+                $detailStatus = 'warn';
+                $needsReindex++;
+            } elseif ($mode === 'unavailable') {
+                $detailStatus = 'unknown';
+            } else {
+                $detailStatus = 'ok';
+            }
+
+            $details[] = new ProbeDetailRow(
+                'indexer',
+                $indexerId,
+                $detailStatus,
+                sprintf('state=%s;mode=%s', $state, $mode)
+            );
+        }
+
+        $overallStatus = 'ok';
+        if ($unavailableStateCount > 0) {
+            $overallStatus = 'unknown';
+        } elseif ($needsReindex > 0) {
+            $overallStatus = 'warn';
+        } elseif ($unavailableModeCount > 0) {
+            $overallStatus = 'unknown';
+        }
+
+        return new ProbeSnapshot(
+            $this->getCode(),
+            $overallStatus,
+            sprintf(
+                '%d indexers, %d need reindex, modes=%s',
+                $indexerCount,
+                $needsReindex,
+                $unavailableStateCount > 0 || $unavailableModeCount > 0 ? 'unavailable' : 'ok'
+            ),
+            $details
+        );
+    }
+
+    private function requiresReindex(string $state): bool
+    {
+        return in_array(strtolower((string) $state), ['invalid', 'reindex-required', 'reindex_required'], true);
+    }
+}

--- a/Console/Command/ChaosDonkeyStatus.php
+++ b/Console/Command/ChaosDonkeyStatus.php
@@ -10,6 +10,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ChaosDonkeyStatus extends Command
 {
+    private const ACTION_LABELS = [
+        'reindex_all' => 'Reindex all',
+        'cache_flush' => 'Cache flush',
+        'graphql_pipeline_stress' => 'GraphQL pipeline stress',
+        'indexer_status_snapshot' => 'Indexer status snapshot',
+        'cache_backend_health_snapshot' => 'Cache backend health snapshot',
+        'cron_queue_health_snapshot' => 'Cron queue health snapshot',
+    ];
+
     private Config $config;
 
     public function __construct(Config $config)
@@ -45,7 +54,13 @@ class ChaosDonkeyStatus extends Command
         $output->writeln('Last kick: ' . $lastKick);
         $output->writeln('Last outcome: ' . $lastOutcome);
 
+        $output->writeln('');
+        $output->writeln('Configured Action/Probe Toggles');
+
+        foreach (self::ACTION_LABELS as $actionCode => $label) {
+            $output->writeln($label . ': ' . ($this->config->isActionEnabled($actionCode) ? 'Enabled' : 'Disabled'));
+        }
+
         return Command::SUCCESS;
     }
 }
-

--- a/Cron/ChaosDonkeyKickCron.php
+++ b/Cron/ChaosDonkeyKickCron.php
@@ -62,6 +62,12 @@ class ChaosDonkeyKickCron
 
         $result = $this->kickExecutor->execute();
 
+        foreach ($result['messages'] as $message) {
+            if (str_starts_with($message, 'Probe[') || str_starts_with($message, 'ProbeDetail[')) {
+                $this->logMessage($message);
+            }
+        }
+
         $this->logMessage(sprintf(
             'ChaosDonkey cron completed with kick %d and outcome %s.',
             $result['kick'],

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -12,6 +12,9 @@ class Config
     public const CONFIG_PATH_ENABLE_REINDEX_ALL = 'admin/chaos_donkey/enable_reindex_all';
     public const CONFIG_PATH_ENABLE_CACHE_FLUSH = 'admin/chaos_donkey/enable_cache_flush';
     public const CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS = 'admin/chaos_donkey/enable_graphql_pipeline_stress';
+    public const CONFIG_PATH_ENABLE_INDEXER_STATUS_SNAPSHOT = 'admin/chaos_donkey/enable_indexer_status_snapshot';
+    public const CONFIG_PATH_ENABLE_CACHE_BACKEND_HEALTH_SNAPSHOT = 'admin/chaos_donkey/enable_cache_backend_health_snapshot';
+    public const CONFIG_PATH_ENABLE_CRON_QUEUE_HEALTH_SNAPSHOT = 'admin/chaos_donkey/enable_cron_queue_health_snapshot';
     public const CONFIG_PATH_CRON_ENABLED = 'admin/chaos_donkey/cron_enabled';
     public const CONFIG_PATH_CRON_EXPRESSION = 'admin/chaos_donkey/cron_expression';
     public const CONFIG_PATH_CRON_ALLOWED_HOURS = 'admin/chaos_donkey/cron_allowed_hours';
@@ -48,6 +51,21 @@ class Config
     public function isGraphQlPipelineStressEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
     {
         return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS, $scopeType, $scopeCode);
+    }
+
+    public function isIndexerStatusSnapshotEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_INDEXER_STATUS_SNAPSHOT, $scopeType, $scopeCode);
+    }
+
+    public function isCacheBackendHealthSnapshotEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_CACHE_BACKEND_HEALTH_SNAPSHOT, $scopeType, $scopeCode);
+    }
+
+    public function isCronQueueHealthSnapshotEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::CONFIG_PATH_ENABLE_CRON_QUEUE_HEALTH_SNAPSHOT, $scopeType, $scopeCode);
     }
 
     public function isCronEnabled(string $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, ?string $scopeCode = null): bool
@@ -120,6 +138,9 @@ class Config
             'reindex_all' => $this->isReindexAllEnabled(),
             'cache_flush' => $this->isCacheFlushEnabled(),
             'graphql_pipeline_stress' => $this->isGraphQlPipelineStressEnabled(),
+            'indexer_status_snapshot' => $this->isIndexerStatusSnapshotEnabled(),
+            'cache_backend_health_snapshot' => $this->isCacheBackendHealthSnapshotEnabled(),
+            'cron_queue_health_snapshot' => $this->isCronQueueHealthSnapshotEnabled(),
             default => true,
         };
     }

--- a/Model/KickExecutor.php
+++ b/Model/KickExecutor.php
@@ -12,6 +12,9 @@ class KickExecutor
         'reindex_all',
         'cache_flush',
         'graphql_pipeline_stress',
+        'indexer_status_snapshot',
+        'cache_backend_health_snapshot',
+        'cron_queue_health_snapshot',
     ];
 
     public function __construct(
@@ -36,7 +39,7 @@ class KickExecutor
         $enabledActions = $this->getEnabledActions();
 
         if (!in_array(true, $enabledActions, true)) {
-            $messages[] = 'All configured chaos actions are disabled. Rolling non-action outcomes only.';
+            $messages[] = 'All configured chaos actions/probes are disabled. Rolling non-action outcomes only.';
         }
 
         $kick = 0;
@@ -70,7 +73,11 @@ class KickExecutor
                 }
             }
 
-            $messages[] = $result->getSummary();
+            $summary = $result->getSummary();
+
+            if ($summary !== '') {
+                $messages[] = $summary;
+            }
         } else {
             match ($outcome) {
                 'critical_failure' => $messages[] = 'Critical Failure! Better check all of your donkeys.',

--- a/Model/Probe/ClockInterface.php
+++ b/Model/Probe/ClockInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model\Probe;
+
+use DateTimeImmutable;
+
+interface ClockInterface
+{
+    public function nowUtc(): DateTimeImmutable;
+}

--- a/Model/Probe/ProbeDetailRow.php
+++ b/Model/Probe/ProbeDetailRow.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model\Probe;
+
+class ProbeDetailRow
+{
+    public function __construct(
+        private string $subsystem,
+        private string $item,
+        private string $status,
+        private string $message
+    ) {
+    }
+
+    public function getSubsystem(): string
+    {
+        return $this->subsystem;
+    }
+
+    public function getItem(): string
+    {
+        return $this->item;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/Model/Probe/ProbeOutputFormatter.php
+++ b/Model/Probe/ProbeOutputFormatter.php
@@ -48,7 +48,7 @@ class ProbeOutputFormatter
     public function formatDetail(string $probeCode, ProbeDetailRow $detail): string
     {
         return sprintf(
-            'Probe[%s] subsystem=%s item=%s status=%s msg="%s"',
+            'ProbeDetail[%s] subsystem=%s item=%s status=%s value="%s"',
             $probeCode,
             $detail->getSubsystem(),
             $detail->getItem(),

--- a/Model/Probe/ProbeOutputFormatter.php
+++ b/Model/Probe/ProbeOutputFormatter.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model\Probe;
+
+class ProbeOutputFormatter
+{
+    /**
+     * @var array<string, int>
+     */
+    private const array SEVERITY_RANKING = [
+        'warn' => 4,
+        'unavailable' => 3,
+        'unknown' => 2,
+        'ok' => 1,
+    ];
+
+    public function formatSummary(ProbeSnapshot $snapshot): string
+    {
+        return sprintf(
+            'Probe[%s] status=%s msg="%s"',
+            $snapshot->getProbeCode(),
+            $snapshot->getStatus(),
+            $snapshot->getSummary()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function formatTopDetails(ProbeSnapshot $snapshot): string
+    {
+        $details = $snapshot->getDetails();
+
+        if (!$snapshot->isPreserveDetailOrder()) {
+            usort($details, [$this, 'compareDetails']);
+        }
+
+        $lines = [];
+
+        foreach (array_slice($details, 0, 5) as $detail) {
+            $lines[] = $this->formatDetail($snapshot->getProbeCode(), $detail);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    public function formatDetail(string $probeCode, ProbeDetailRow $detail): string
+    {
+        return sprintf(
+            'Probe[%s] subsystem=%s item=%s status=%s msg="%s"',
+            $probeCode,
+            $detail->getSubsystem(),
+            $detail->getItem(),
+            $detail->getStatus(),
+            $detail->getMessage()
+        );
+    }
+
+    public function formatLines(ProbeSnapshot $snapshot): string
+    {
+        $topDetails = $this->formatTopDetails($snapshot);
+
+        if ($topDetails === '') {
+            return $this->formatSummary($snapshot);
+        }
+
+        return $this->formatSummary($snapshot) . "\n" . $topDetails;
+    }
+
+    private function severityRank(string $status): int
+    {
+        return self::SEVERITY_RANKING[strtolower($status)] ?? 0;
+    }
+
+    private function compareDetails(ProbeDetailRow $a, ProbeDetailRow $b): int
+    {
+        $severityCompare = $this->severityRank($b->getStatus()) <=> $this->severityRank($a->getStatus());
+
+        if ($severityCompare !== 0) {
+            return $severityCompare;
+        }
+
+        $subsystemCompare = $a->getSubsystem() <=> $b->getSubsystem();
+        if ($subsystemCompare !== 0) {
+            return $subsystemCompare;
+        }
+
+        return $a->getItem() <=> $b->getItem();
+    }
+}

--- a/Model/Probe/ProbeOutputFormatter.php
+++ b/Model/Probe/ProbeOutputFormatter.php
@@ -21,7 +21,7 @@ class ProbeOutputFormatter
             'Probe[%s] status=%s msg="%s"',
             $snapshot->getProbeCode(),
             $snapshot->getStatus(),
-            $snapshot->getSummary()
+            $this->normalizeMessage($snapshot->getSummary())
         );
     }
 
@@ -53,7 +53,7 @@ class ProbeOutputFormatter
             $detail->getSubsystem(),
             $detail->getItem(),
             $detail->getStatus(),
-            $detail->getMessage()
+            $this->normalizeMessage($detail->getMessage())
         );
     }
 
@@ -87,5 +87,20 @@ class ProbeOutputFormatter
         }
 
         return $a->getItem() <=> $b->getItem();
+    }
+
+    private function normalizeMessage(string $message): string
+    {
+        $normalized = str_replace("\r\n", "\n", $message);
+        $normalized = str_replace("\r", "\n", $normalized);
+
+        $replacements = [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            "\n" => '\\n',
+            "\t" => '\\t',
+        ];
+
+        return strtr($normalized, $replacements);
     }
 }

--- a/Model/Probe/ProbeOutputFormatter.php
+++ b/Model/Probe/ProbeOutputFormatter.php
@@ -8,7 +8,7 @@ class ProbeOutputFormatter
     /**
      * @var array<string, int>
      */
-    private const array SEVERITY_RANKING = [
+    private const SEVERITY_RANKING = [
         'warn' => 4,
         'unavailable' => 3,
         'unknown' => 2,

--- a/Model/Probe/ProbeSnapshot.php
+++ b/Model/Probe/ProbeSnapshot.php
@@ -12,7 +12,7 @@ class ProbeSnapshot
         private string $probeCode,
         private string $status,
         private string $summary,
-        private array $details = [],
+        private array $details,
         private bool $preserveDetailOrder = false
     ) {
     }

--- a/Model/Probe/ProbeSnapshot.php
+++ b/Model/Probe/ProbeSnapshot.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model\Probe;
+
+class ProbeSnapshot
+{
+    /**
+     * @param list<ProbeDetailRow> $details
+     */
+    public function __construct(
+        private string $probeCode,
+        private string $status,
+        private string $summary,
+        private array $details = [],
+        private bool $preserveDetailOrder = false
+    ) {
+    }
+
+    public function getProbeCode(): string
+    {
+        return $this->probeCode;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getSummary(): string
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @return list<ProbeDetailRow>
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
+    public function isPreserveDetailOrder(): bool
+    {
+        return $this->preserveDetailOrder;
+    }
+}

--- a/Model/Probe/SystemClock.php
+++ b/Model/Probe/SystemClock.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model\Probe;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+class SystemClock implements ClockInterface
+{
+    public function nowUtc(): DateTimeImmutable
+    {
+        return new DateTimeImmutable('now', new DateTimeZone('UTC'));
+    }
+}

--- a/Model/RollOutcomeResolver.php
+++ b/Model/RollOutcomeResolver.php
@@ -12,6 +12,9 @@ class RollOutcomeResolver
             2 => 'reindex_all',
             3 => 'cache_flush',
             4 => 'graphql_pipeline_stress',
+            5 => 'indexer_status_snapshot',
+            6 => 'cache_backend_health_snapshot',
+            7 => 'cron_queue_health_snapshot',
             20 => 'critical_success',
             default => 'napping',
         };

--- a/README.md
+++ b/README.md
@@ -89,11 +89,21 @@ Cron log behavior:
 - Non-probe chatter from the executor result is intentionally not logged by cron to keep logs focused.
 
 ### `bin/magento chaosdonkey:status`
-Prints real module status values from config/state:
-- Enabled (`Yes`/`No`)
-- Last run (`Never` if unset)
-- Last kick (`Never` if unset)
-- Last outcome (`Never` if unset)
+Shows the operator-oriented status snapshot for ChaosDonkey.
+
+- Enabled (`Yes`/`No`) — reads `admin/chaos_donkey/enabled` using the command's existing store-scoped behavior.
+- Last run (`Never` if unset) — reads `admin/chaos_donkey/last_run` from default scope.
+- Last kick (`Never` if unset) — reads `admin/chaos_donkey/last_kick` from default scope.
+- Last outcome (`Never` if unset) — reads `admin/chaos_donkey/last_outcome` from default scope.
+- Configured Action/Probe Toggles (default scope):
+  - `Reindex all: Enabled|Disabled`
+  - `Cache flush: Enabled|Disabled`
+  - `GraphQL pipeline stress: Enabled|Disabled`
+  - `Indexer status snapshot: Enabled|Disabled`
+  - `Cache backend health snapshot: Enabled|Disabled`
+  - `Cron queue health snapshot: Enabled|Disabled`
+
+This makes the runtime values (last run/kick/outcome) and toggle rows explicit as `default` scope configuration, while module enabled state follows the existing store-scoped status command behavior.
 
 ## Reindex Behavior
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Rolls a D20 and executes a mapped outcome.
   - `admin/chaos_donkey/enable_reindex_all`
   - `admin/chaos_donkey/enable_cache_flush`
   - `admin/chaos_donkey/enable_graphql_pipeline_stress`
-- If a disabled action outcome is rolled, rerolls up to 20 times.
-- If all action toggles are disabled, prints `All configured chaos actions are disabled. Rolling non-action outcomes only.`
-- If reroll attempts are exhausted, falls back to `napping`.
-- If enabled, saves:
+  - `admin/chaos_donkey/enable_indexer_status_snapshot`
+  - `admin/chaos_donkey/enable_cache_backend_health_snapshot`
+  - `admin/chaos_donkey/enable_cron_queue_health_snapshot`
+  - If a disabled action outcome is rolled, rerolls up to 20 times.
+  - If all action/probe toggles are disabled, prints `All configured chaos actions/probes are disabled. Rolling non-action outcomes only.`
+  - If reroll attempts are exhausted, falls back to `napping`.
+  - If enabled, saves:
   - `admin/chaos_donkey/last_run` (ISO-8601 timestamp)
   - `admin/chaos_donkey/last_kick` (rolled value)
   - `admin/chaos_donkey/last_outcome` (outcome key)
@@ -24,10 +27,21 @@ Current outcome mapping:
 - `2`: reindex all indexers (`reindex_all`)
 - `3`: flush cache types (`cache_flush`)
 - `4`: run internal GraphQL pipeline stress (`graphql_pipeline_stress`)
+- `5`: indexer status snapshot probe (`indexer_status_snapshot`)
+- `6`: cache backend health snapshot probe (`cache_backend_health_snapshot`)
+- `7`: cron/queue health snapshot probe (`cron_queue_health_snapshot`)
 - `20`: critical success message (`critical_success`)
 - default: napping message (`napping`)
 
-For action outcomes, `chaosdonkey:kick` resolves an action code and executes a DI-wired action service from the action pool.
+Rolls `5`, `6`, and `7` are the fixed probe outcomes for the new read-only probes.
+
+For outcomes, `chaosdonkey:kick` resolves an action code and executes a DI-wired action service from the action pool.
+
+Probe actions return their output as canonical lines in the command result payload:
+- `Probe[<outcome>] status=<status> msg="<message>"`
+- `ProbeDetail[<outcome>] subsystem=<name> item=<name> status=<status> value="<value>"`
+
+`chaosdonkey:kick` prints each line from the executor payload as-is, without reformatting.
 
 ## Cron Automation
 
@@ -53,6 +67,11 @@ Cron execution skips when:
 - the current hour is outside the allowed window
 
 When it does run, cron delegates to the same kick execution pipeline as `chaosdonkey:kick`, so rerolls, action toggles, and state persistence behave the same way.
+
+Cron log behavior:
+- Always logs startup, skip reasons, and completion.
+- Logs only probe/probe-detail lines from command output (`Probe[...]`, `ProbeDetail[...]`) and preserves them unchanged.
+- Non-probe chatter from the executor result is intentionally not logged by cron to keep logs focused.
 
 ### `bin/magento chaosdonkey:status`
 Prints real module status values from config/state:

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Rolls a D20 and executes a mapped outcome.
   - `admin/chaos_donkey/enable_indexer_status_snapshot`
   - `admin/chaos_donkey/enable_cache_backend_health_snapshot`
   - `admin/chaos_donkey/enable_cron_queue_health_snapshot`
-  - If a disabled action outcome is rolled, rerolls up to 20 times.
-  - If all action/probe toggles are disabled, prints `All configured chaos actions/probes are disabled. Rolling non-action outcomes only.`
-  - If reroll attempts are exhausted, falls back to `napping`.
-  - If enabled, saves:
+- If enabled and an action/probe executes, the command delegates execution to `KickExecutor`.
+- If a disabled action outcome is rolled, rerolls up to 20 times.
+- If all action/probe toggles are disabled, prints `All configured chaos actions/probes are disabled. Rolling non-action outcomes only.`
+- If reroll attempts are exhausted, falls back to `napping`.
+- If enabled, saves:
   - `admin/chaos_donkey/last_run` (ISO-8601 timestamp)
   - `admin/chaos_donkey/last_kick` (rolled value)
   - `admin/chaos_donkey/last_outcome` (outcome key)
@@ -42,6 +43,20 @@ Probe actions return their output as canonical lines in the command result paylo
 - `ProbeDetail[<outcome>] subsystem=<name> item=<name> status=<status> value="<value>"`
 
 `chaosdonkey:kick` prints each line from the executor payload as-is, without reformatting.
+
+### Task 8 verification evidence
+
+Executed in-repo in this worktree:
+
+- Targeted kick command test:
+  - `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
+- Targeted status command test:
+  - `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyStatusTest.php`
+- Full suite:
+  - `vendor/bin/phpunit`
+- Manual checks attempted:
+  - Attempted `bin/magento` config/status/kick checks, but this worktree is module-only and does not include Magento bootstrap.
+  - Limitation: `bin/magento` is unavailable (`zsh: no such file or directory`).
 
 ## Cron Automation
 

--- a/Test/Stubs/Magento/Framework/App/Cache/Frontend/Pool.php
+++ b/Test/Stubs/Magento/Framework/App/Cache/Frontend/Pool.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Cache\Frontend;
+
+class Pool
+{
+    public function get(string $cacheType): mixed
+    {
+        return null;
+    }
+}

--- a/Test/Stubs/Magento/Framework/App/Cache/TypeListInterface.php
+++ b/Test/Stubs/Magento/Framework/App/Cache/TypeListInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Cache;
+
+interface TypeListInterface
+{
+    public function getTypes(): array;
+}

--- a/Test/Stubs/Magento/Framework/App/ResourceConnection.php
+++ b/Test/Stubs/Magento/Framework/App/ResourceConnection.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\App;
+
+class ResourceConnection
+{
+    public function getTableName(string $entityTable): string
+    {
+        return $entityTable;
+    }
+
+    public function getConnection(): mixed
+    {
+        return null;
+    }
+}

--- a/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Framework\DB\Adapter;
+
+interface AdapterInterface
+{
+    public function isTableExists(string $tableName): bool;
+
+    /**
+     * @param array<string, mixed> $bind
+     */
+    public function fetchOne(string $sql, array $bind = []): mixed;
+}

--- a/Test/Stubs/Magento/Indexer/Model/IndexerRegistry.php
+++ b/Test/Stubs/Magento/Indexer/Model/IndexerRegistry.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace Magento\Indexer\Model;
+
+class IndexerRegistry
+{
+    public function get(string $indexerId): mixed
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
+++ b/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
@@ -55,7 +55,7 @@ class CacheBackendHealthSnapshotTest extends TestCase
         self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=config status=ok value="enabled=true"', $result['output']);
         self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=layout status=ok value="enabled=false"', $result['output']);
         self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=full_page status=ok value="enabled=true"', $result['output']);
-        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=ok value="cachebackendhealthsnapshotsafebackend"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=ok value="cachebackendhealthsnapshotsafebackend"', $result['output']);
     }
 
     public function testItWritesWarnSummaryWhenDefaultBackendResolutionFails(): void
@@ -82,7 +82,7 @@ class CacheBackendHealthSnapshotTest extends TestCase
             $this->splitOutput($result['output'])[0]
         );
         self::assertStringContainsString(
-            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=warn value="resolution_failed"',
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=warn value="resolution_failed"',
             $result['output']
         );
     }
@@ -147,10 +147,6 @@ class CacheBackendHealthSnapshotTest extends TestCase
         );
         self::assertStringContainsString(
             'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=unknown value="unavailable"',
-            $result['output']
-        );
-        self::assertStringContainsString(
-            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=unknown value="unavailable"',
             $result['output']
         );
     }

--- a/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
+++ b/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
@@ -179,6 +179,110 @@ class CacheBackendHealthSnapshotTest extends TestCase
         );
     }
 
+    public function testItHandlesMalformedMetadataRowsWithoutThrowing(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+                'weird_object' => new \stdClass(),
+                'missing_status' => [],
+                'layout' => ['status' => 0],
+            ]);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(new CacheBackendHealthSnapshotSafeBackend()));
+
+        $result = $this->runProbe();
+
+        self::assertTrue($result['instance']->isSuccess());
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=ok msg="4 cache types, 1 enabled, backend adapter=cachebackendhealthsnapshotsafebackend"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=config status=ok value="enabled=true"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=weird_object status=ok value="enabled=false"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=missing_status status=ok value="enabled=false"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=layout status=ok value="enabled=false"', $result['output']);
+    }
+
+    public function testItSanitizesAdapterLabelForBackendClassName(): void
+    {
+        $refl = new \ReflectionMethod(CacheBackendHealthSnapshot::class, 'sanitizeAdapterLabel');
+        $refl->setAccessible(true);
+
+        $action = new CacheBackendHealthSnapshot(
+            $this->cacheTypeList,
+            $this->frontendPool,
+            new ProbeOutputFormatter()
+        );
+
+        $label = $refl->invoke(
+            $action,
+            'Vendor\\Module\\Backend--Adapter!Name'
+        );
+
+        self::assertSame('backend_adapter_name', $label);
+    }
+
+    public function testAdapterLabelFallsBackToUnavailableWhenSanitizedEmpty(): void
+    {
+        $refl = new \ReflectionMethod(CacheBackendHealthSnapshot::class, 'sanitizeAdapterLabel');
+        $refl->setAccessible(true);
+
+        $action = new CacheBackendHealthSnapshot(
+            $this->cacheTypeList,
+            $this->frontendPool,
+            new ProbeOutputFormatter()
+        );
+
+        $label = $refl->invoke($action, '!!!');
+
+        self::assertSame('unavailable', $label);
+    }
+
+    public function testItTreatsNullDefaultFrontendAsUnavailable(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+                'layout' => ['status' => 0],
+            ]);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(null);
+
+        $result = $this->runProbe();
+
+        self::assertFalse($result['instance']->isSuccess());
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=unknown msg="cache snapshot unavailable"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertSame(4, count($this->splitOutput($result['output'])));
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=config status=ok value="enabled=true"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=layout status=ok value="enabled=false"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=unknown value="unavailable"',
+            $result['output']
+        );
+    }
+
     private function runProbe(): array
     {
         $output = new BufferedOutput();

--- a/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
+++ b/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
@@ -210,39 +210,58 @@ class CacheBackendHealthSnapshotTest extends TestCase
         self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=layout status=ok value="enabled=false"', $result['output']);
     }
 
-    public function testItSanitizesAdapterLabelForBackendClassName(): void
+    public function testItSanitizesUnsafeAdapterClassNameWhenResolvingBackend(): void
     {
-        $refl = new \ReflectionMethod(CacheBackendHealthSnapshot::class, 'sanitizeAdapterLabel');
-        $refl->setAccessible(true);
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+            ]);
 
-        $action = new CacheBackendHealthSnapshot(
-            $this->cacheTypeList,
-            $this->frontendPool,
-            new ProbeOutputFormatter()
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(new ÄBackend()));
+
+        $result = $this->runProbe();
+
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=ok msg="1 cache types, 1 enabled, backend adapter=backend"',
+            $this->splitOutput($result['output'])[0]
         );
-
-        $label = $refl->invoke(
-            $action,
-            'Vendor\\Module\\Backend--Adapter!Name'
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=ok value="backend"',
+            $result['output']
         );
-
-        self::assertSame('backend_adapter_name', $label);
     }
 
-    public function testAdapterLabelFallsBackToUnavailableWhenSanitizedEmpty(): void
+    public function testAdapterLabelFallsBackToUnavailableWhenUnsanitizable(): void
     {
-        $refl = new \ReflectionMethod(CacheBackendHealthSnapshot::class, 'sanitizeAdapterLabel');
-        $refl->setAccessible(true);
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+            ]);
 
-        $action = new CacheBackendHealthSnapshot(
-            $this->cacheTypeList,
-            $this->frontendPool,
-            new ProbeOutputFormatter()
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(new Ä()));
+
+        $result = $this->runProbe();
+
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=ok msg="1 cache types, 1 enabled, backend adapter=unavailable"',
+            $this->splitOutput($result['output'])[0]
         );
-
-        $label = $refl->invoke($action, '!!!');
-
-        self::assertSame('unavailable', $label);
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=ok value="unavailable"',
+            $result['output']
+        );
     }
 
     public function testItTreatsNullDefaultFrontendAsUnavailable(): void
@@ -330,5 +349,13 @@ final class CacheBackendHealthSnapshotFakeFrontend
 }
 
 final class CacheBackendHealthSnapshotSafeBackend
+{
+}
+
+final class ÄBackend
+{
+}
+
+final class Ä
 {
 }

--- a/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
+++ b/Test/Unit/Action/CacheBackendHealthSnapshotTest.php
@@ -1,0 +1,234 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Action;
+
+use Magento\Framework\App\Cache\Frontend\Pool;
+use Magento\Framework\App\Cache\TypeListInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShaunMcManus\ChaosDonkey\Action\CacheBackendHealthSnapshot;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CacheBackendHealthSnapshotTest extends TestCase
+{
+    private TypeListInterface&MockObject $cacheTypeList;
+    private Pool&MockObject $frontendPool;
+
+    protected function setUp(): void
+    {
+        $this->cacheTypeList = $this->createMock(TypeListInterface::class);
+        $this->frontendPool = $this->createMock(Pool::class);
+    }
+
+    public function testItWritesOkSummaryAndDetailRowsWhenMetadataAndDefaultBackendResolve(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+                'layout' => ['status' => 0],
+                'full_page' => ['status' => 1],
+            ]);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(new CacheBackendHealthSnapshotSafeBackend()));
+
+        $result = $this->runProbe();
+
+        self::assertSame('cache_backend_health_snapshot', $result['instance']->getOutcomeCode());
+        self::assertSame('', $result['instance']->getSummary());
+        self::assertTrue($result['instance']->isSuccess());
+
+        $lines = $this->splitOutput($result['output']);
+        self::assertCount(5, $lines);
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=ok msg="3 cache types, 2 enabled, backend adapter=cachebackendhealthsnapshotsafebackend"',
+            $lines[0]
+        );
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=config status=ok value="enabled=true"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=layout status=ok value="enabled=false"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=full_page status=ok value="enabled=true"', $result['output']);
+        self::assertStringContainsString('ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=ok value="cachebackendhealthsnapshotsafebackend"', $result['output']);
+    }
+
+    public function testItWritesWarnSummaryWhenDefaultBackendResolutionFails(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+            ]);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(null, new RuntimeException('backend failed')));
+
+        $result = $this->runProbe();
+
+        self::assertTrue($result['instance']->isSuccess());
+
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=warn msg="1 cache types, 1 enabled, backend adapter resolution degraded"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=warn value="resolution_failed"',
+            $result['output']
+        );
+    }
+
+    public function testItWritesUnknownSummaryWhenMetadataCannotBeRead(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willThrowException(new RuntimeException('metadata unavailable'));
+
+        $this->frontendPool
+            ->expects(self::never())
+            ->method('get');
+
+        $result = $this->runProbe();
+
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertFalse($result['instance']->isSuccess());
+        self::assertSame(2, count($lines));
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=unknown msg="cache snapshot unavailable"',
+            $lines[0]
+        );
+        self::assertSame(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=metadata status=unknown value="unavailable"',
+            $lines[1]
+        );
+    }
+
+    public function testItWritesUnknownSummaryWhenDefaultFrontendUnavailable(): void
+    {
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn([
+                'config' => ['status' => 1],
+                'full_page' => ['status' => 0],
+            ]);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willThrowException(new RuntimeException('default frontend missing'));
+
+        $result = $this->runProbe();
+
+        self::assertFalse($result['instance']->isSuccess());
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=unknown msg="cache snapshot unavailable"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=config status=ok value="enabled=true"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=full_page status=ok value="enabled=false"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=unknown value="unavailable"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=backend status=unknown value="unavailable"',
+            $result['output']
+        );
+    }
+
+    public function testItLimitsOutputToSummaryPlusFiveDetails(): void
+    {
+        $types = [];
+        for ($i = 1; $i <= 7; $i++) {
+            $types['type_' . $i] = ['status' => 1];
+        }
+
+        $this->cacheTypeList
+            ->expects(self::once())
+            ->method('getTypes')
+            ->willReturn($types);
+
+        $this->frontendPool
+            ->expects(self::once())
+            ->method('get')
+            ->with('default')
+            ->willReturn(new CacheBackendHealthSnapshotFakeFrontend(new CacheBackendHealthSnapshotSafeBackend()));
+
+        $result = $this->runProbe();
+
+        self::assertCount(7, $types);
+        self::assertLessThanOrEqual(6, count($this->splitOutput($result['output'])));
+        self::assertSame(
+            'Probe[cache_backend_health_snapshot] status=ok msg="7 cache types, 7 enabled, backend adapter=cachebackendhealthsnapshotsafebackend"',
+            $this->splitOutput($result['output'])[0]
+        );
+    }
+
+    private function runProbe(): array
+    {
+        $output = new BufferedOutput();
+        $action = new CacheBackendHealthSnapshot(
+            $this->cacheTypeList,
+            $this->frontendPool,
+            new ProbeOutputFormatter(),
+        );
+
+        $result = $action->execute($output);
+
+        return [
+            'output' => trim($output->fetch()),
+            'instance' => $result,
+        ];
+    }
+
+    private function splitOutput(string $output): array
+    {
+        if ($output === '') {
+            return [];
+        }
+
+        return preg_split('/\r\n|\r|\n/', $output);
+    }
+}
+
+final class CacheBackendHealthSnapshotFakeFrontend
+{
+    public function __construct(
+        private ?object $backend = null,
+        private ?\Throwable $backendFailure = null
+    ) {
+    }
+
+    public function getBackend(): object
+    {
+        if ($this->backendFailure !== null) {
+            throw $this->backendFailure;
+        }
+
+        return $this->backend ?? new class {
+        };
+    }
+}
+
+final class CacheBackendHealthSnapshotSafeBackend
+{
+}

--- a/Test/Unit/Action/CronQueueHealthSnapshotTest.php
+++ b/Test/Unit/Action/CronQueueHealthSnapshotTest.php
@@ -382,6 +382,7 @@ class CronQueueHealthSnapshotTest extends TestCase
 
         self::assertStringContainsString('status=unknown', $lines[0]);
         self::assertStringContainsString('queue=unknown', $lines[0]);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=ok value="true"', $result['output']);
         self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
         self::assertFalse($result['instance']->isSuccess());
     }

--- a/Test/Unit/Action/CronQueueHealthSnapshotTest.php
+++ b/Test/Unit/Action/CronQueueHealthSnapshotTest.php
@@ -204,7 +204,7 @@ class CronQueueHealthSnapshotTest extends TestCase
 
         self::assertStringContainsString('status=warn', $lines[0]);
         self::assertStringContainsString('queue=unknown', $lines[0]);
-        self::assertStringContainsString('subsystem=queue item=tables_present status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=unavailable value="false"', $result['output']);
         self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
         self::assertStringContainsString('subsystem=cron item=failures_last_60m status=warn value="3"', $result['output']);
         self::assertStringContainsString('subsystem=cron item=pending_older_15m status=ok value="1"', $result['output']);
@@ -399,7 +399,7 @@ class CronQueueHealthSnapshotTest extends TestCase
         self::assertStringContainsString('status=unknown', $this->splitOutput($result['output'])[0]);
         self::assertStringContainsString('cron=unknown, queue=unknown, failures_last_60m=n/a, pending_older_15m=n/a, activity_last_60m=n/a', $this->splitOutput($result['output'])[0]);
         self::assertStringContainsString('subsystem=cron item=failures_last_60m status=unknown value="n/a"', $result['output']);
-        self::assertStringContainsString('subsystem=queue item=tables_present status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=unavailable value="false"', $result['output']);
         self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
         self::assertFalse($result['instance']->isSuccess());
     }

--- a/Test/Unit/Action/CronQueueHealthSnapshotTest.php
+++ b/Test/Unit/Action/CronQueueHealthSnapshotTest.php
@@ -1,0 +1,436 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Action;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShaunMcManus\ChaosDonkey\Action\CronQueueHealthSnapshot;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ClockInterface;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CronQueueHealthSnapshotTest extends TestCase
+{
+    private ResourceConnection&MockObject $resourceConnection;
+    private AdapterInterface&MockObject $adapter;
+    private ClockInterface&MockObject $clock;
+
+    protected function setUp(): void
+    {
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->adapter = $this->createMock(AdapterInterface::class);
+        $this->clock = $this->createMock(ClockInterface::class);
+    }
+
+    public function testItEmitsFixedOrderFourRowsAndSummaryForHealthyState(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('0', '0', '7');
+
+        $result = $this->runProbe();
+
+        self::assertSame('cron_queue_health_snapshot', $result['instance']->getOutcomeCode());
+        self::assertSame('', $result['instance']->getSummary());
+        self::assertTrue($result['instance']->isSuccess());
+
+        $lines = $this->splitOutput($result['output']);
+        self::assertCount(5, $lines);
+
+        self::assertSame(
+            'Probe[cron_queue_health_snapshot] status=ok msg="cron=healthy, queue=healthy, failures_last_60m=0, pending_older_15m=0, activity_last_60m=7"',
+            $lines[0]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=failures_last_60m status=ok value="0"',
+            $lines[1]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=pending_older_15m status=ok value="0"',
+            $lines[2]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=tables_present status=ok value="true"',
+            $lines[3]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=activity_last_60m status=ok value="7"',
+            $lines[4]
+        );
+    }
+
+    public function testItWarnsWhenCronHasRecentFailures(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('3', '0', '9');
+
+        $result = $this->runProbe();
+
+        self::assertStringContainsString('status=warn', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('cron=degraded', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('subsystem=cron item=failures_last_60m status=warn value="3"', $result['output']);
+        self::assertTrue($result['instance']->isSuccess());
+    }
+
+    public function testItWarnsWhenCronHasPendingBacklogOlderThanFifteenMinutes(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('0', '12', '9');
+
+        $result = $this->runProbe();
+
+        self::assertStringContainsString('status=warn', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('cron=degraded', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('subsystem=cron item=pending_older_15m status=warn value="12"', $result['output']);
+    }
+
+    public function testItWarnsQueueWhenCronWarnsAndQueueHasNoActivity(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('4', '0', '0');
+
+        $result = $this->runProbe();
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertStringContainsString('status=warn', $lines[0]);
+        self::assertStringContainsString('cron=degraded', $lines[0]);
+        self::assertStringContainsString('queue=degraded', $lines[0]);
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=failures_last_60m status=warn value="4"',
+            $lines[1]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=pending_older_15m status=warn value="0"',
+            $lines[2]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=tables_present status=ok value="true"',
+            $lines[3]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=activity_last_60m status=warn value="0"',
+            $lines[4]
+        );
+        self::assertTrue($result['instance']->isSuccess());
+    }
+
+    public function testSpecialPrecedenceQueueUnavailableWithCronOkLeavesOverallOk(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => false,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('0', '0');
+
+        $result = $this->runProbe();
+
+        self::assertStringContainsString('status=ok msg="cron=healthy, queue=unavailable', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=unavailable value="false"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unavailable value="n/a"', $result['output']);
+        self::assertTrue($result['instance']->isSuccess());
+    }
+
+    public function testItUsesInjectedClockForLookbackWindowBoundaries(): void
+    {
+        $now = new DateTimeImmutable('2026-03-29 10:30:45', new DateTimeZone('UTC'));
+        $capturedBinds = [];
+
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow($now);
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnCallback(function (string $sql, array $bind) use (&$capturedBinds): string {
+                $capturedBinds[] = $bind;
+
+                if (str_contains($sql, 'status IN')) {
+                    return '1';
+                }
+
+                if (str_contains($sql, 'status =')) {
+                    return '2';
+                }
+
+                return '5';
+            });
+
+        $this->runProbe();
+
+        self::assertSame('2026-03-29 09:30:45', $capturedBinds[0]['lookback_60m']);
+        self::assertSame('2026-03-29 10:15:45', $capturedBinds[1]['lookback_15m']);
+        self::assertSame('2026-03-29 09:30:45', $capturedBinds[2]['lookback_60m']);
+    }
+
+    public function testItNormalizesCronQueryFailureToUnknownWithoutDroppingRows(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $callCount = 0;
+
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('fetchOne')
+            ->willReturnCallback(function (string $sql, array $bind) use (&$callCount): string {
+                if ($callCount === 0) {
+                    $callCount++;
+
+                    throw new RuntimeException('cron query failed');
+                }
+
+                return '4';
+            });
+
+        $result = $this->runProbe();
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertStringContainsString('status=unknown', $lines[0]);
+        self::assertStringContainsString('cron=unknown', $lines[0]);
+        self::assertStringContainsString('subsystem=cron item=failures_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=cron item=pending_older_15m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=ok value="4"', $result['output']);
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItNormalizesQueueQueryFailureToUnknownWithoutDroppingRows(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnCallback(function (string $sql, array $bind): string {
+                if (str_contains($sql, 'status IN')) {
+                    return '0';
+                }
+
+                if (str_contains($sql, 'status =')) {
+                    return '0';
+                }
+
+                throw new RuntimeException('queue query failed');
+            });
+
+        $result = $this->runProbe();
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertStringContainsString('status=unknown', $lines[0]);
+        self::assertStringContainsString('queue=unknown', $lines[0]);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItReturnsUnknownWhenDbConnectionCannotBeObtained(): void
+    {
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willThrowException(new RuntimeException('db unavailable'));
+
+        $result = $this->runProbe();
+
+        self::assertStringContainsString('status=unknown', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('cron=unknown, queue=unknown, failures_last_60m=n/a, pending_older_15m=n/a, activity_last_60m=n/a', $this->splitOutput($result['output'])[0]);
+        self::assertStringContainsString('subsystem=cron item=failures_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testOutputLinesAreBoundedToSummaryPlusAtMostFiveDetails(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(3))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('2', '11', '14');
+
+        $result = $this->runProbe();
+
+        $lines = $this->splitOutput($result['output']);
+        self::assertLessThanOrEqual(6, count($lines));
+    }
+
+    public function testCanonicalProbeEnvelopeFormattingForWarningsAndFailures(): void
+    {
+        $this->configureResourceConnection($this->adapter);
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => false,
+            'queue_message' => false,
+            'queue_message_status' => false,
+        ]);
+
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('1', '12');
+
+        $result = $this->runProbe();
+
+        $resultLines = $this->splitOutput($result['output']);
+        self::assertSame(
+            'Probe[cron_queue_health_snapshot] status=warn msg="cron=degraded, queue=unavailable, failures_last_60m=1, pending_older_15m=12, activity_last_60m=n/a"',
+            $resultLines[0]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=failures_last_60m status=warn value="1"',
+            $resultLines[1]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=pending_older_15m status=warn value="12"',
+            $resultLines[2]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=tables_present status=unavailable value="false"',
+            $resultLines[3]
+        );
+        self::assertSame(
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=activity_last_60m status=unavailable value="n/a"',
+            $resultLines[4]
+        );
+    }
+
+    private function configureResourceConnection(AdapterInterface $adapter): void
+    {
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($adapter);
+
+        $this->resourceConnection
+            ->method('getTableName')
+            ->willReturnCallback(static function (string $table): string {
+                return $table;
+            });
+    }
+
+    private function configureClockNow(DateTimeImmutable $now): void
+    {
+        $this->clock
+            ->expects(self::once())
+            ->method('nowUtc')
+            ->willReturn($now);
+    }
+
+    private function configureTablePresence(array $presence): void
+    {
+        $this->adapter
+            ->method('isTableExists')
+            ->willReturnCallback(static function (string $table) use ($presence): bool {
+                return $presence[$table] ?? false;
+            });
+    }
+
+    private function runProbe(): array
+    {
+        $output = new BufferedOutput();
+        $action = new CronQueueHealthSnapshot(
+            $this->resourceConnection,
+            $this->clock,
+            new ProbeOutputFormatter()
+        );
+
+        $result = $action->execute($output);
+
+        return [
+            'output' => trim($output->fetch()),
+            'instance' => $result,
+        ];
+    }
+
+    private function splitOutput(string $output): array
+    {
+        if ($output === '') {
+            return [];
+        }
+
+        return preg_split('/\r\n|\r|\n/', $output);
+    }
+}

--- a/Test/Unit/Action/CronQueueHealthSnapshotTest.php
+++ b/Test/Unit/Action/CronQueueHealthSnapshotTest.php
@@ -9,12 +9,14 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use RuntimeException;
 use ShaunMcManus\ChaosDonkey\Action\CronQueueHealthSnapshot;
 use ShaunMcManus\ChaosDonkey\Model\Probe\ClockInterface;
 use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[AllowMockObjectsWithoutExpectations]
 class CronQueueHealthSnapshotTest extends TestCase
 {
     private ResourceConnection&MockObject $resourceConnection;
@@ -122,6 +124,93 @@ class CronQueueHealthSnapshotTest extends TestCase
         self::assertStringContainsString('subsystem=cron item=pending_older_15m status=warn value="12"', $result['output']);
     }
 
+    public function testItNormalizesCronGetTableNameExceptions(): void
+    {
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->adapter);
+
+        $this->resourceConnection
+            ->expects(self::exactly(4))
+            ->method('getTableName')
+            ->willReturnCallback(function (string $table): string {
+                if ($table === 'cron_schedule') {
+                    throw new RuntimeException('cron table metadata failed');
+                }
+
+                return $table;
+            });
+
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+
+        $this->configureTablePresence([
+            'cron_schedule' => true,
+            'queue' => true,
+            'queue_message' => true,
+            'queue_message_status' => true,
+        ]);
+
+        $this->adapter
+            ->expects(self::once())
+            ->method('fetchOne')
+            ->willReturn('2');
+
+        $result = $this->runProbe();
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertStringContainsString('status=unknown', $lines[0]);
+        self::assertStringContainsString('cron=unknown', $lines[0]);
+        self::assertStringContainsString('subsystem=cron item=failures_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=cron item=pending_older_15m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=ok value="2"', $result['output']);
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItNormalizesQueueIsTableExistsExceptions(): void
+    {
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->adapter);
+
+        $this->resourceConnection
+            ->expects(self::exactly(4))
+            ->method('getTableName')
+            ->willReturnCallback(static function (string $table): string {
+                return $table;
+            });
+
+        $this->configureClockNow(new DateTimeImmutable('2026-01-01 12:00:00', new DateTimeZone('UTC')));
+
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('isTableExists')
+            ->willReturnCallback(function (string $table): bool {
+                if ($table === 'queue') {
+                    throw new RuntimeException('queue existence check failed');
+                }
+
+                return true;
+            });
+
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('3', '1');
+
+        $result = $this->runProbe();
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertStringContainsString('status=warn', $lines[0]);
+        self::assertStringContainsString('queue=unknown', $lines[0]);
+        self::assertStringContainsString('subsystem=queue item=tables_present status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=queue item=activity_last_60m status=unknown value="n/a"', $result['output']);
+        self::assertStringContainsString('subsystem=cron item=failures_last_60m status=warn value="3"', $result['output']);
+        self::assertStringContainsString('subsystem=cron item=pending_older_15m status=ok value="1"', $result['output']);
+        self::assertTrue($result['instance']->isSuccess());
+    }
+
     public function testItWarnsQueueWhenCronWarnsAndQueueHasNoActivity(): void
     {
         $this->configureResourceConnection($this->adapter);
@@ -149,7 +238,7 @@ class CronQueueHealthSnapshotTest extends TestCase
             $lines[1]
         );
         self::assertSame(
-            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=pending_older_15m status=warn value="0"',
+            'ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=pending_older_15m status=ok value="0"',
             $lines[2]
         );
         self::assertSame(
@@ -394,7 +483,6 @@ class CronQueueHealthSnapshotTest extends TestCase
     private function configureClockNow(DateTimeImmutable $now): void
     {
         $this->clock
-            ->expects(self::once())
             ->method('nowUtc')
             ->willReturn($now);
     }

--- a/Test/Unit/Action/IndexerStatusSnapshotTest.php
+++ b/Test/Unit/Action/IndexerStatusSnapshotTest.php
@@ -224,6 +224,36 @@ class IndexerStatusSnapshotTest extends TestCase
         self::assertCount(2, $this->splitOutput($result['output']));
     }
 
+    public function testItFallsBackToUnknownWhenEnumerationThrowsDuringIteration(): void
+    {
+        $indexers = (function (): iterable {
+            throw new RuntimeException('indexer enumeration failed');
+            yield new FakeIndexer('should_not_be_reached', 'valid', false);
+        })();
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::never())
+            ->method('get');
+
+        $result = $this->runProbe([]);
+
+        self::assertFalse($result['instance']->isSuccess());
+        self::assertStringContainsString(
+            'Probe[indexer_status_snapshot] status=unknown msg="n/a indexers, n/a need reindex, modes=unavailable"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=enumeration status=unknown value="unavailable"',
+            $result['output']
+        );
+        self::assertCount(2, $this->splitOutput($result['output']));
+    }
+
     public function testItLimitsOutputToSummaryPlusFiveTopDetails(): void
     {
         $indexers = [];

--- a/Test/Unit/Action/IndexerStatusSnapshotTest.php
+++ b/Test/Unit/Action/IndexerStatusSnapshotTest.php
@@ -27,8 +27,8 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testItWritesAllOkSummaryAndDetailsForHealthyIndexers(): void
     {
         $indexerMap = [
-            'catalogsearch_fulltext' => new FakeIndexer('catalogsearch_fulltext', 'valid', false),
-            'catalog_product_price' => new FakeIndexer('catalog_product_price', 'valid', true),
+            'catalogsearch_fulltext' => new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', false),
+            'catalog_product_price' => new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'valid', true),
         ];
         $indexers = array_values($indexerMap);
 
@@ -40,7 +40,7 @@ class IndexerStatusSnapshotTest extends TestCase
         $this->indexerRegistry
             ->expects(self::exactly(2))
             ->method('get')
-            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): FakeIndexer {
+            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): IndexerStatusSnapshotFakeIndexer {
                 return $indexerMap[$indexerId];
             });
 
@@ -62,8 +62,8 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testItReportsWarnSummaryAndRowsWhenIndexersNeedReindex(): void
     {
         $indexerMap = [
-            'catalog_product_price' => new FakeIndexer('catalog_product_price', 'invalid', false),
-            'catalogsearch_fulltext' => new FakeIndexer('catalogsearch_fulltext', 'valid', false),
+            'catalog_product_price' => new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'invalid', false),
+            'catalogsearch_fulltext' => new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', false),
         ];
         $indexers = array_values($indexerMap);
 
@@ -75,7 +75,7 @@ class IndexerStatusSnapshotTest extends TestCase
         $this->indexerRegistry
             ->expects(self::exactly(2))
             ->method('get')
-            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): FakeIndexer {
+            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): IndexerStatusSnapshotFakeIndexer {
                 return $indexerMap[$indexerId];
             });
 
@@ -87,10 +87,38 @@ class IndexerStatusSnapshotTest extends TestCase
         self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=warn value="state=invalid;mode=realtime"', $output);
     }
 
+    public function testItKeepsWarnWhenInvalidAndUnknownRowsAreMixed(): void
+    {
+        $indexers = [
+            new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'invalid', false),
+            new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', false, null, null, new RuntimeException('id failed')),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::once())
+            ->method('get')
+            ->with('catalog_product_price')
+            ->willReturn($indexers[0]);
+
+        $result = $this->runProbe($indexers);
+
+        self::assertSame(
+            'Probe[indexer_status_snapshot] status=warn msg="2 indexers, 1 need reindex, modes=unavailable"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertTrue($result['instance']->isSuccess());
+        self::assertStringContainsString('subsystem=indexer item=enumeration status=unknown value="unavailable"', $result['output']);
+    }
+
     public function testItMarksUnknownWhenModeIsUnavailableEvenIfStateIsHealthy(): void
     {
         $indexers = [
-            new FakeIndexer('catalogsearch_fulltext', 'valid', false, null, new RuntimeException('mode failed')),
+            new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', false, null, new RuntimeException('mode failed')),
         ];
 
         $this->collectionFactory
@@ -122,7 +150,7 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testItMarksUnknownWhenStateCannotBeRead(): void
     {
         $indexers = [
-            new FakeIndexer('catalogsearch_fulltext', 'valid', false, new RuntimeException('state failed')),
+            new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', false, new RuntimeException('state failed')),
         ];
 
         $this->collectionFactory
@@ -152,13 +180,17 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testItMarksUnknownWhenIndexerIdCannotBeRead(): void
     {
         $indexers = [
-            new FakeIndexer('catalog_product_price', 'valid', false, null, null, new RuntimeException('id failed')),
+            new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'valid', false, null, null, new RuntimeException('id failed')),
         ];
 
         $this->collectionFactory
             ->expects(self::once())
             ->method('create')
             ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::never())
+            ->method('get');
 
         $result = $this->runProbe($indexers);
 
@@ -176,7 +208,7 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testItKeepsWarnStateWhenReindexNeededAndModeUnavailable(): void
     {
         $indexers = [
-            new FakeIndexer('catalog_product_price', 'invalid', true, null, new RuntimeException('mode failed')),
+            new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'invalid', true, null, new RuntimeException('mode failed')),
         ];
 
         $this->collectionFactory
@@ -210,6 +242,10 @@ class IndexerStatusSnapshotTest extends TestCase
             ->method('create')
             ->willThrowException(new RuntimeException('indexer listing failed'));
 
+        $this->indexerRegistry
+            ->expects(self::never())
+            ->method('get');
+
         $result = $this->runProbe([]);
 
         self::assertFalse($result['instance']->isSuccess());
@@ -228,7 +264,7 @@ class IndexerStatusSnapshotTest extends TestCase
     {
         $indexers = (function (): iterable {
             throw new RuntimeException('indexer enumeration failed');
-            yield new FakeIndexer('should_not_be_reached', 'valid', false);
+            yield new IndexerStatusSnapshotFakeIndexer('should_not_be_reached', 'valid', false);
         })();
 
         $this->collectionFactory
@@ -258,7 +294,7 @@ class IndexerStatusSnapshotTest extends TestCase
     {
         $indexers = [];
         for ($i = 1; $i <= 7; $i++) {
-            $indexers[] = new FakeIndexer('indexer_' . $i, 'valid', $i % 2 === 0);
+            $indexers[] = new IndexerStatusSnapshotFakeIndexer('indexer_' . $i, 'valid', $i % 2 === 0);
         }
 
         $this->collectionFactory
@@ -269,10 +305,10 @@ class IndexerStatusSnapshotTest extends TestCase
         $this->indexerRegistry
             ->expects(self::exactly(7))
             ->method('get')
-            ->willReturnCallback(static function (string $indexerId) use ($indexers): FakeIndexer {
+            ->willReturnCallback(static function (string $indexerId) use ($indexers): IndexerStatusSnapshotFakeIndexer {
                 $needle = array_filter(
                     $indexers,
-                    static function (FakeIndexer $indexer) use ($indexerId): bool {
+                    static function (IndexerStatusSnapshotFakeIndexer $indexer) use ($indexerId): bool {
                         return $indexer->getId() === $indexerId;
                     }
                 );
@@ -293,8 +329,8 @@ class IndexerStatusSnapshotTest extends TestCase
     public function testEachDetailContainsStateAndModeTuple(): void
     {
         $indexers = [
-            new FakeIndexer('catalog_product_price', 'valid', false),
-            new FakeIndexer('catalogsearch_fulltext', 'valid', true),
+            new IndexerStatusSnapshotFakeIndexer('catalog_product_price', 'valid', false),
+            new IndexerStatusSnapshotFakeIndexer('catalogsearch_fulltext', 'valid', true),
         ];
 
         $this->collectionFactory
@@ -305,7 +341,7 @@ class IndexerStatusSnapshotTest extends TestCase
         $this->indexerRegistry
             ->expects(self::exactly(2))
             ->method('get')
-            ->willReturnCallback(static function (string $indexerId) use ($indexers): FakeIndexer {
+            ->willReturnCallback(static function (string $indexerId) use ($indexers): IndexerStatusSnapshotFakeIndexer {
                 if ($indexerId === 'catalogsearch_fulltext') {
                     return $indexers[1];
                 }
@@ -352,7 +388,7 @@ class IndexerStatusSnapshotTest extends TestCase
     }
 }
 
-final class FakeIndexer
+final class IndexerStatusSnapshotFakeIndexer
 {
     public function __construct(
         private string $id,

--- a/Test/Unit/Action/IndexerStatusSnapshotTest.php
+++ b/Test/Unit/Action/IndexerStatusSnapshotTest.php
@@ -54,9 +54,9 @@ class IndexerStatusSnapshotTest extends TestCase
         $lines = $this->splitOutput($output);
 
         self::assertCount(3, $lines);
-        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="2 indexers, 0 need reindex, modes=ok"', $lines[0]);
-        self::assertStringContainsString('subsystem=indexer item=catalogsearch_fulltext status=ok msg="state=valid;mode=realtime"', $output);
-        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=ok msg="state=valid;mode=schedule"', $output);
+        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="2 indexers, 0 need reindex, modes: schedule=1, realtime=1"', $lines[0]);
+        self::assertStringContainsString('subsystem=indexer item=catalogsearch_fulltext status=ok value="state=valid;mode=realtime"', $output);
+        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=ok value="state=valid;mode=schedule"', $output);
     }
 
     public function testItReportsWarnSummaryAndRowsWhenIndexersNeedReindex(): void
@@ -83,8 +83,8 @@ class IndexerStatusSnapshotTest extends TestCase
 
         $lines = $this->splitOutput($output);
 
-        self::assertSame('Probe[indexer_status_snapshot] status=warn msg="2 indexers, 1 need reindex, modes=ok"', $lines[0]);
-        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=warn msg="state=invalid;mode=realtime"', $output);
+        self::assertSame('Probe[indexer_status_snapshot] status=warn msg="2 indexers, 1 need reindex, modes: schedule=0, realtime=2"', $lines[0]);
+        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=warn value="state=invalid;mode=realtime"', $output);
     }
 
     public function testItMarksUnknownWhenModeIsUnavailableEvenIfStateIsHealthy(): void
@@ -113,7 +113,7 @@ class IndexerStatusSnapshotTest extends TestCase
             $lines[0]
         );
         self::assertStringContainsString(
-            'subsystem=indexer item=catalogsearch_fulltext status=unknown msg="state=valid;mode=unavailable"',
+            'subsystem=indexer item=catalogsearch_fulltext status=unknown value="state=valid;mode=unavailable"',
             $result['output']
         );
         self::assertFalse($result['instance']->isSuccess());
@@ -143,7 +143,31 @@ class IndexerStatusSnapshotTest extends TestCase
             $this->splitOutput($result['output'])[0]
         );
         self::assertStringContainsString(
-            'subsystem=indexer item=catalogsearch_fulltext status=unknown msg="state=unavailable;mode=realtime"',
+            'subsystem=indexer item=catalogsearch_fulltext status=unknown value="state=unavailable;mode=realtime"',
+            $result['output']
+        );
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItMarksUnknownWhenIndexerIdCannotBeRead(): void
+    {
+        $indexers = [
+            new FakeIndexer('catalog_product_price', 'valid', false, null, null, new RuntimeException('id failed')),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $result = $this->runProbe($indexers);
+
+        self::assertSame(
+            'Probe[indexer_status_snapshot] status=unknown msg="1 indexers, 0 need reindex, modes=unavailable"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertStringContainsString(
+            'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=enumeration status=unknown value="unavailable"',
             $result['output']
         );
         self::assertFalse($result['instance']->isSuccess());
@@ -174,7 +198,7 @@ class IndexerStatusSnapshotTest extends TestCase
             $result['output']
         );
         self::assertStringContainsString(
-            'subsystem=indexer item=catalog_product_price status=warn msg="state=invalid;mode=unavailable"',
+            'subsystem=indexer item=catalog_product_price status=warn value="state=invalid;mode=unavailable"',
             $result['output']
         );
     }
@@ -194,7 +218,7 @@ class IndexerStatusSnapshotTest extends TestCase
             $result['output']
         );
         self::assertStringContainsString(
-            'Probe[indexer_status_snapshot] subsystem=indexer item=enumeration status=unknown msg="unavailable"',
+            'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=enumeration status=unknown value="unavailable"',
             $result['output']
         );
         self::assertCount(2, $this->splitOutput($result['output']));
@@ -233,7 +257,7 @@ class IndexerStatusSnapshotTest extends TestCase
 
         $lines = $this->splitOutput($result['output']);
         self::assertLessThanOrEqual(6, count($lines));
-        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="7 indexers, 0 need reindex, modes=ok"', $lines[0]);
+        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="7 indexers, 0 need reindex, modes: schedule=3, realtime=4"', $lines[0]);
     }
 
     public function testEachDetailContainsStateAndModeTuple(): void
@@ -262,11 +286,11 @@ class IndexerStatusSnapshotTest extends TestCase
         $result = $this->runProbe($indexers);
 
         self::assertMatchesRegularExpression(
-            '/subsystem=indexer item=catalog_product_price status=ok msg="state=valid;mode=(realtime|schedule)"/',
+            '/subsystem=indexer item=catalog_product_price status=ok value="state=valid;mode=(realtime|schedule)"/',
             $result['output']
         );
         self::assertMatchesRegularExpression(
-            '/subsystem=indexer item=catalogsearch_fulltext status=ok msg="state=valid;mode=(realtime|schedule)"/',
+            '/subsystem=indexer item=catalogsearch_fulltext status=ok value="state=valid;mode=(realtime|schedule)"/',
             $result['output']
         );
     }
@@ -306,11 +330,16 @@ final class FakeIndexer
         private bool $scheduled,
         private ?Throwable $statusFailure = null,
         private ?Throwable $modeFailure = null,
+        private ?Throwable $idFailure = null,
     ) {
     }
 
     public function getId(): string
     {
+        if ($this->idFailure !== null) {
+            throw $this->idFailure;
+        }
+
         return $this->id;
     }
 

--- a/Test/Unit/Action/IndexerStatusSnapshotTest.php
+++ b/Test/Unit/Action/IndexerStatusSnapshotTest.php
@@ -1,0 +1,334 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Action;
+
+use Magento\Indexer\Model\Indexer\CollectionFactory;
+use Magento\Indexer\Model\IndexerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ShaunMcManus\ChaosDonkey\Action\IndexerStatusSnapshot;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+
+class IndexerStatusSnapshotTest extends TestCase
+{
+    private CollectionFactory&MockObject $collectionFactory;
+    private IndexerRegistry&MockObject $indexerRegistry;
+
+    protected function setUp(): void
+    {
+        $this->collectionFactory = $this->createMock(CollectionFactory::class);
+        $this->indexerRegistry = $this->createMock(IndexerRegistry::class);
+    }
+
+    public function testItWritesAllOkSummaryAndDetailsForHealthyIndexers(): void
+    {
+        $indexerMap = [
+            'catalogsearch_fulltext' => new FakeIndexer('catalogsearch_fulltext', 'valid', false),
+            'catalog_product_price' => new FakeIndexer('catalog_product_price', 'valid', true),
+        ];
+        $indexers = array_values($indexerMap);
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): FakeIndexer {
+                return $indexerMap[$indexerId];
+            });
+
+        $result = $this->runProbe($indexers);
+        $output = $result['output'];
+
+        self::assertSame('indexer_status_snapshot', $result['instance']->getOutcomeCode());
+        self::assertSame('', $result['instance']->getSummary());
+        self::assertTrue($result['instance']->isSuccess());
+
+        $lines = $this->splitOutput($output);
+
+        self::assertCount(3, $lines);
+        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="2 indexers, 0 need reindex, modes=ok"', $lines[0]);
+        self::assertStringContainsString('subsystem=indexer item=catalogsearch_fulltext status=ok msg="state=valid;mode=realtime"', $output);
+        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=ok msg="state=valid;mode=schedule"', $output);
+    }
+
+    public function testItReportsWarnSummaryAndRowsWhenIndexersNeedReindex(): void
+    {
+        $indexerMap = [
+            'catalog_product_price' => new FakeIndexer('catalog_product_price', 'invalid', false),
+            'catalogsearch_fulltext' => new FakeIndexer('catalogsearch_fulltext', 'valid', false),
+        ];
+        $indexers = array_values($indexerMap);
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->willReturnCallback(static function (string $indexerId) use ($indexerMap): FakeIndexer {
+                return $indexerMap[$indexerId];
+            });
+
+        $output = $this->runProbe($indexers)['output'];
+
+        $lines = $this->splitOutput($output);
+
+        self::assertSame('Probe[indexer_status_snapshot] status=warn msg="2 indexers, 1 need reindex, modes=ok"', $lines[0]);
+        self::assertStringContainsString('subsystem=indexer item=catalog_product_price status=warn msg="state=invalid;mode=realtime"', $output);
+    }
+
+    public function testItMarksUnknownWhenModeIsUnavailableEvenIfStateIsHealthy(): void
+    {
+        $indexers = [
+            new FakeIndexer('catalogsearch_fulltext', 'valid', false, null, new RuntimeException('mode failed')),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::once())
+            ->method('get')
+            ->with('catalogsearch_fulltext')
+            ->willReturn($indexers[0]);
+
+        $result = $this->runProbe($indexers);
+
+        $lines = $this->splitOutput($result['output']);
+
+        self::assertSame(
+            'Probe[indexer_status_snapshot] status=unknown msg="1 indexers, 0 need reindex, modes=unavailable"',
+            $lines[0]
+        );
+        self::assertStringContainsString(
+            'subsystem=indexer item=catalogsearch_fulltext status=unknown msg="state=valid;mode=unavailable"',
+            $result['output']
+        );
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItMarksUnknownWhenStateCannotBeRead(): void
+    {
+        $indexers = [
+            new FakeIndexer('catalogsearch_fulltext', 'valid', false, new RuntimeException('state failed')),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::once())
+            ->method('get')
+            ->with('catalogsearch_fulltext')
+            ->willReturn($indexers[0]);
+
+        $result = $this->runProbe($indexers);
+
+        self::assertSame(
+            'Probe[indexer_status_snapshot] status=unknown msg="1 indexers, 0 need reindex, modes=unavailable"',
+            $this->splitOutput($result['output'])[0]
+        );
+        self::assertStringContainsString(
+            'subsystem=indexer item=catalogsearch_fulltext status=unknown msg="state=unavailable;mode=realtime"',
+            $result['output']
+        );
+        self::assertFalse($result['instance']->isSuccess());
+    }
+
+    public function testItKeepsWarnStateWhenReindexNeededAndModeUnavailable(): void
+    {
+        $indexers = [
+            new FakeIndexer('catalog_product_price', 'invalid', true, null, new RuntimeException('mode failed')),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::once())
+            ->method('get')
+            ->with('catalog_product_price')
+            ->willReturn($indexers[0]);
+
+        $result = $this->runProbe($indexers);
+
+        self::assertTrue($result['instance']->isSuccess());
+        self::assertStringContainsString(
+            'Probe[indexer_status_snapshot] status=warn msg="1 indexers, 1 need reindex, modes=unavailable"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'subsystem=indexer item=catalog_product_price status=warn msg="state=invalid;mode=unavailable"',
+            $result['output']
+        );
+    }
+
+    public function testItFallsBackToUnknownWhenEnumerationFails(): void
+    {
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willThrowException(new RuntimeException('indexer listing failed'));
+
+        $result = $this->runProbe([]);
+
+        self::assertFalse($result['instance']->isSuccess());
+        self::assertStringContainsString(
+            'Probe[indexer_status_snapshot] status=unknown msg="n/a indexers, n/a need reindex, modes=unavailable"',
+            $result['output']
+        );
+        self::assertStringContainsString(
+            'Probe[indexer_status_snapshot] subsystem=indexer item=enumeration status=unknown msg="unavailable"',
+            $result['output']
+        );
+        self::assertCount(2, $this->splitOutput($result['output']));
+    }
+
+    public function testItLimitsOutputToSummaryPlusFiveTopDetails(): void
+    {
+        $indexers = [];
+        for ($i = 1; $i <= 7; $i++) {
+            $indexers[] = new FakeIndexer('indexer_' . $i, 'valid', $i % 2 === 0);
+        }
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::exactly(7))
+            ->method('get')
+            ->willReturnCallback(static function (string $indexerId) use ($indexers): FakeIndexer {
+                $needle = array_filter(
+                    $indexers,
+                    static function (FakeIndexer $indexer) use ($indexerId): bool {
+                        return $indexer->getId() === $indexerId;
+                    }
+                );
+
+                return array_shift($needle);
+            });
+
+        $result = $this->runProbe($indexers);
+
+        self::assertSame('indexer_status_snapshot', $result['instance']->getOutcomeCode());
+        self::assertSame('', $result['instance']->getSummary());
+
+        $lines = $this->splitOutput($result['output']);
+        self::assertLessThanOrEqual(6, count($lines));
+        self::assertSame('Probe[indexer_status_snapshot] status=ok msg="7 indexers, 0 need reindex, modes=ok"', $lines[0]);
+    }
+
+    public function testEachDetailContainsStateAndModeTuple(): void
+    {
+        $indexers = [
+            new FakeIndexer('catalog_product_price', 'valid', false),
+            new FakeIndexer('catalogsearch_fulltext', 'valid', true),
+        ];
+
+        $this->collectionFactory
+            ->expects(self::once())
+            ->method('create')
+            ->willReturn($indexers);
+
+        $this->indexerRegistry
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->willReturnCallback(static function (string $indexerId) use ($indexers): FakeIndexer {
+                if ($indexerId === 'catalogsearch_fulltext') {
+                    return $indexers[1];
+                }
+
+                return $indexers[0];
+            });
+
+        $result = $this->runProbe($indexers);
+
+        self::assertMatchesRegularExpression(
+            '/subsystem=indexer item=catalog_product_price status=ok msg="state=valid;mode=(realtime|schedule)"/',
+            $result['output']
+        );
+        self::assertMatchesRegularExpression(
+            '/subsystem=indexer item=catalogsearch_fulltext status=ok msg="state=valid;mode=(realtime|schedule)"/',
+            $result['output']
+        );
+    }
+
+    private function runProbe(array $indexers): array
+    {
+        $output = new BufferedOutput();
+        $action = new IndexerStatusSnapshot(
+            $this->collectionFactory,
+            $this->indexerRegistry,
+            new ProbeOutputFormatter()
+        );
+
+        $result = $action->execute($output);
+
+        return [
+            'output' => trim($output->fetch()),
+            'instance' => $result,
+        ];
+    }
+
+    private function splitOutput(string $output): array
+    {
+        if ($output === '') {
+            return [];
+        }
+
+        return preg_split('/\r\n|\r|\n/', $output);
+    }
+}
+
+final class FakeIndexer
+{
+    public function __construct(
+        private string $id,
+        private string $status,
+        private bool $scheduled,
+        private ?Throwable $statusFailure = null,
+        private ?Throwable $modeFailure = null,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        if ($this->statusFailure !== null) {
+            throw $this->statusFailure;
+        }
+
+        return $this->status;
+    }
+
+    public function isScheduled(): bool
+    {
+        if ($this->modeFailure !== null) {
+            throw $this->modeFailure;
+        }
+
+        return $this->scheduled;
+    }
+}

--- a/Test/Unit/Compatibility/TypedClassConstantCompatibilityTest.php
+++ b/Test/Unit/Compatibility/TypedClassConstantCompatibilityTest.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Compatibility;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use FilesystemIterator;
+
+class TypedClassConstantCompatibilityTest extends TestCase
+{
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function runtimePhpSourceProvider(): array
+    {
+        $moduleRoot = dirname(__DIR__, 3);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($moduleRoot, FilesystemIterator::SKIP_DOTS)
+        );
+
+        $runtimeFiles = [];
+        $moduleRootLength = strlen($moduleRoot) + 1;
+
+        foreach ($iterator as $fileInfo) {
+            if (!$fileInfo->isFile()) {
+                continue;
+            }
+
+            if (!str_ends_with($fileInfo->getFilename(), '.php')) {
+                continue;
+            }
+
+            $absolutePath = $fileInfo->getPathname();
+            $relativePath = substr($absolutePath, $moduleRootLength);
+
+            if (str_starts_with($relativePath, 'Test/')
+                || str_starts_with($relativePath, 'vendor/')
+            ) {
+                continue;
+            }
+
+            $runtimeFiles[] = [$relativePath];
+        }
+
+        usort(
+            $runtimeFiles,
+            static fn(array $a, array $b): int => strnatcasecmp($a[0], $b[0])
+        );
+
+        return $runtimeFiles;
+    }
+
+    /**
+     * @return array<int, array<int, array<int, string>|string>>
+     */
+    public static function classConstantDeclarationProvider(): array
+    {
+        return [
+            [
+                'const string FOO = "typed";',
+                ['const string FOO ='],
+            ],
+            [
+                'private const array BAR = ["typed"];',
+                ['private const array BAR ='],
+            ],
+            [
+                "final\npublic const string BAZ = 'x';",
+                ['final public const string BAZ ='],
+            ],
+            [
+                "public const\nstring QUX = \"yes\";",
+                ['public const string QUX ='],
+            ],
+            [
+                'public const int BAZ = 42;',
+                ['public const int BAZ ='],
+            ],
+            [
+                'private const BLAH = "untyped";',
+                [],
+            ],
+            [
+                'protected const BLAH = ["no type" , "another"], BAZ = "second";',
+                [],
+            ],
+        ];
+    }
+
+    #[DataProvider('runtimePhpSourceProvider')]
+    public function testFeatureSourceFilesDoNotUseTypedClassConstants(string $relativePath): void
+    {
+        $moduleRoot = dirname(__DIR__, 3);
+        $filePath = $moduleRoot . '/' . $relativePath;
+
+        $source = (string) file_get_contents($filePath);
+
+        self::assertStringContainsString('<?php', $source);
+
+        $foundTyped = $this->collectTypedClassConstantDeclarations($source);
+
+        self::assertSame(
+            [],
+            $foundTyped,
+            sprintf(
+                'Typed class constants are not supported on some runtimes. Update this module source file: %s. Found:%s',
+                $relativePath,
+                PHP_EOL . ' - ' . implode(PHP_EOL . ' - ', $foundTyped)
+            )
+        );
+    }
+
+    #[DataProvider('classConstantDeclarationProvider')]
+    public function testClassConstantTypedDetectionWorksForVisibleAndNonVisibleDeclarations(string $source, array $expectedMatches): void
+    {
+        self::assertSame(
+            $expectedMatches,
+            $this->collectTypedClassConstantDeclarations($source),
+            'Typed class-constant detection no longer identifies constants consistently.'
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectTypedClassConstantDeclarations(string $source): array
+    {
+        $tokenizableSource = str_starts_with(trim($source), '<?') ? $source : "<?php\n" . $source;
+        $tokens = token_get_all($tokenizableSource);
+        $matches = [];
+
+        for ($i = 0; $i < count($tokens); $i++) {
+            if (!$this->isTokenType($tokens[$i], T_CONST)) {
+                continue;
+            }
+
+            $equalIndex = $this->findNextEqualsToken($tokens, $i + 1);
+            if ($equalIndex === null) {
+                continue;
+            }
+
+            $declarationStart = $this->findTypedDeclarationStart($tokens, $i);
+            if (!$this->isTypedClassConstantDeclaration($tokens, $i + 1, $equalIndex)) {
+                continue;
+            }
+
+            $matches[] = $this->formatDeclarationText($tokens, $declarationStart, $equalIndex);
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function findNextEqualsToken(array $tokens, int $startIndex): ?int
+    {
+        $tokenCount = count($tokens);
+
+        for ($i = $startIndex; $i < $tokenCount; $i++) {
+            if (is_array($tokens[$i])) {
+                if (in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    continue;
+                }
+
+                continue;
+            }
+
+            if ($tokens[$i] === '=') {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    private function isTypedClassConstantDeclaration(array $tokens, int $afterConstIndex, int $equalIndex): bool
+    {
+        $meaningfulTokenCount = 0;
+
+        for ($i = $afterConstIndex; $i < $equalIndex; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                $id = $token[0];
+                if (in_array($id, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    continue;
+                }
+
+                $meaningfulTokenCount++;
+                continue;
+            }
+
+            if ($token === '|' || $token === '?' || $token === '\\') {
+                $meaningfulTokenCount++;
+            }
+        }
+
+        return $meaningfulTokenCount > 1;
+    }
+
+    private function findTypedDeclarationStart(array $tokens, int $constIndex): int
+    {
+        $start = $constIndex;
+
+        for ($i = $constIndex - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                $id = $token[0];
+                if (in_array($id, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    continue;
+                }
+
+                if ($id === T_FINAL || $id === T_PUBLIC || $id === T_PROTECTED || $id === T_PRIVATE) {
+                    $start = $i;
+                    continue;
+                }
+
+                break;
+            }
+
+            break;
+        }
+
+        return $start;
+    }
+
+    private function isTokenType(mixed $token, int $type): bool
+    {
+        return is_array($token) && $token[0] === $type;
+    }
+
+    private function formatDeclarationText(array $tokens, int $start, int $equalIndex): string
+    {
+        $raw = '';
+
+        for ($i = $start; $i <= $equalIndex; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    $raw .= ' ';
+                    continue;
+                }
+
+                $raw .= $token[1];
+                continue;
+            }
+
+            $raw .= $token;
+        }
+
+        return preg_replace('/\s+/', ' ', trim($raw));
+    }
+}

--- a/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
@@ -61,4 +61,42 @@ class ChaosDonkeyKickTest extends TestCase
         self::assertStringContainsString('Cache flush started', $tester->getDisplay());
         self::assertStringContainsString('Cache flush completed', $tester->getDisplay());
     }
+
+    public function testItPrintsProbeLinesUnchangedFromExecutorOutput(): void
+    {
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+
+        $probeSummary = 'Probe[indexer_status_snapshot] status=warn msg="2 indexers, 1 need reindex, modes=unavailable"';
+        $probeDetail = 'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=product_indexer status=warn value="state=invalid; mode=schedule"';
+
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'indexer_status_snapshot',
+                'messages' => [
+                    'ChaosDonkeyKick kicks your Magento. You rolled a 5',
+                    $probeSummary,
+                    $probeDetail,
+                    'The donkeys are napping',
+                ],
+            ]);
+
+        $command = new ChaosDonkeyKick($this->config, $this->kickExecutor);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(
+            [
+                'ChaosDonkeyKick kicks your Magento. You rolled a 5',
+                $probeSummary,
+                $probeDetail,
+                'The donkeys are napping',
+            ],
+            preg_split('/\r?\n/', trim($tester->getDisplay()))
+        );
+    }
 }

--- a/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
@@ -73,6 +73,137 @@ class ChaosDonkeyStatusTest extends TestCase
         $command = new ChaosDonkeyStatus($this->config);
         $tester = new CommandTester($command);
 
+        $exitCode = $tester->execute([]);
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(0, $exitCode);
+        self::assertStringContainsString('Enabled: No', $display);
+        self::assertStringContainsString('Last run: Never', $display);
+        self::assertStringContainsString('Last kick: Never', $display);
+        self::assertStringContainsString('Last outcome: Never', $display);
+
+    }
+
+    public function testItDisplaysCurrentStatusWithActionAndProbeToggles(): void
+    {
+        $actionStates = [
+            'reindex_all' => true,
+            'cache_flush' => false,
+            'graphql_pipeline_stress' => true,
+            'indexer_status_snapshot' => true,
+            'cache_backend_health_snapshot' => false,
+            'cron_queue_health_snapshot' => true,
+        ];
+
+        $requestedActionCodes = [];
+
+        $this->config
+            ->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastRun')
+            ->willReturn('2026-03-28T20:22:00+00:00');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastKick')
+            ->willReturn('2');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastOutcome')
+            ->willReturn('reindex_all');
+        $this->config
+            ->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnCallback(function (string $code) use (&$requestedActionCodes, $actionStates): bool {
+                $requestedActionCodes[] = $code;
+
+                return $actionStates[$code];
+            });
+
+        $command = new ChaosDonkeyStatus($this->config);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([]);
+        $display = trim($tester->getDisplay());
+
+        $expectedOutput = <<<OUTPUT
+ChaosDonkey Status
+Enabled: Yes
+Last run: 2026-03-28T20:22:00+00:00
+Last kick: 2
+Last outcome: reindex_all
+
+Configured Action/Probe Toggles
+Reindex all: Enabled
+Cache flush: Disabled
+GraphQL pipeline stress: Enabled
+Indexer status snapshot: Enabled
+Cache backend health snapshot: Disabled
+Cron queue health snapshot: Enabled
+OUTPUT;
+
+        self::assertSame(0, $exitCode);
+        self::assertSame($expectedOutput, $display);
+        self::assertSame(
+            [
+                'reindex_all',
+                'cache_flush',
+                'graphql_pipeline_stress',
+                'indexer_status_snapshot',
+                'cache_backend_health_snapshot',
+                'cron_queue_health_snapshot',
+            ],
+            $requestedActionCodes
+        );
+        self::assertStringNotContainsString('critical_failure', $display);
+        self::assertStringNotContainsString('critical_success', $display);
+        self::assertStringNotContainsString('napping', $display);
+    }
+
+    public function testItDisplaysDisabledModuleAndMixedToggles(): void
+    {
+        $actionStates = [
+            'reindex_all' => false,
+            'cache_flush' => false,
+            'graphql_pipeline_stress' => true,
+            'indexer_status_snapshot' => true,
+            'cache_backend_health_snapshot' => false,
+            'cron_queue_health_snapshot' => false,
+        ];
+
+        $requestedActionCodes = [];
+
+        $this->config
+            ->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(false);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastRun')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastKick')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastOutcome')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnCallback(function (string $code) use (&$requestedActionCodes, $actionStates): bool {
+                $requestedActionCodes[] = $code;
+
+                return $actionStates[$code];
+            });
+
+        $command = new ChaosDonkeyStatus($this->config);
+        $tester = new CommandTester($command);
+
         $tester->execute([]);
 
         $display = $tester->getDisplay();
@@ -81,5 +212,66 @@ class ChaosDonkeyStatusTest extends TestCase
         self::assertStringContainsString('Last run: Never', $display);
         self::assertStringContainsString('Last kick: Never', $display);
         self::assertStringContainsString('Last outcome: Never', $display);
+        self::assertStringContainsString('Configured Action/Probe Toggles', $display);
+        self::assertStringContainsString('Reindex all: Disabled', $display);
+        self::assertStringContainsString('GraphQL pipeline stress: Enabled', $display);
+        self::assertStringContainsString('Indexer status snapshot: Enabled', $display);
+        self::assertSame(
+            [
+                'reindex_all',
+                'cache_flush',
+                'graphql_pipeline_stress',
+                'indexer_status_snapshot',
+                'cache_backend_health_snapshot',
+                'cron_queue_health_snapshot',
+            ],
+            $requestedActionCodes
+        );
+        self::assertStringNotContainsString('critical_failure', $display);
+        self::assertStringNotContainsString('critical_success', $display);
+        self::assertStringNotContainsString('napping', $display);
+    }
+
+    public function testItShowsAllDisabledTogglesAsDisabled(): void
+    {
+        $this->config
+            ->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(false);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastRun')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastKick')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastOutcome')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturn(false);
+
+        $command = new ChaosDonkeyStatus($this->config);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $display = trim($tester->getDisplay());
+
+        $expectedSection = <<<OUTPUT
+Configured Action/Probe Toggles
+Reindex all: Disabled
+Cache flush: Disabled
+GraphQL pipeline stress: Disabled
+Indexer status snapshot: Disabled
+Cache backend health snapshot: Disabled
+Cron queue health snapshot: Disabled
+OUTPUT;
+
+        self::assertStringContainsString($expectedSection, $display);
     }
 }

--- a/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
+++ b/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
@@ -103,6 +103,145 @@ class ChaosDonkeyKickCronTest extends TestCase
         ], $cron->messages);
     }
 
+    public function testItLogsOnlyProbeAndProbeDetailLinesFromKickResult(): void
+    {
+        $cron = $this->createCron(5);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'napping',
+                'messages' => [
+                    'ChaosDonkeyKick kicks your Magento. You rolled a 5',
+                    'Probe[indexer_status_snapshot] status=ok msg="2 indexers"',
+                    'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=foo status=ok value="bar"',
+                    'The donkeys are napping',
+                ],
+            ]);
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Executing ChaosDonkey cron at hour 5.',
+            'Probe[indexer_status_snapshot] status=ok msg="2 indexers"',
+            'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=foo status=ok value="bar"',
+            'ChaosDonkey cron completed with kick 5 and outcome napping.',
+        ], $cron->messages);
+    }
+
+    public function testItSkipsNonProbeLinesFromKickResultMessages(): void
+    {
+        $cron = $this->createCron(5);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'napping',
+                'messages' => [
+                    'ChaosDonkeyKick kicks your Magento. You rolled a 7',
+                    'The donkeys are napping',
+                ],
+            ]);
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Executing ChaosDonkey cron at hour 5.',
+            'ChaosDonkey cron completed with kick 5 and outcome napping.',
+        ], $cron->messages);
+    }
+
+    public function testItPreservesProbeOutputOrder(): void
+    {
+        $cron = $this->createCron(5);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'napping',
+                'messages' => [
+                    'Probe[indexer_status_snapshot] status=ok msg="first"',
+                    'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=first status=ok value="value"',
+                    'Some non-probe chatter',
+                    'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=backend status=warn value="value"',
+                    'Probe[cache_backend_health_snapshot] status=warn msg="second"',
+                ],
+            ]);
+
+        $cron->execute();
+
+        self::assertSame([
+            'ChaosDonkey cron started.',
+            'Executing ChaosDonkey cron at hour 5.',
+            'Probe[indexer_status_snapshot] status=ok msg="first"',
+            'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=first status=ok value="value"',
+            'ProbeDetail[cache_backend_health_snapshot] subsystem=cache item=backend status=warn value="value"',
+            'Probe[cache_backend_health_snapshot] status=warn msg="second"',
+            'ChaosDonkey cron completed with kick 5 and outcome napping.',
+        ], $cron->messages);
+    }
+
+    public function testItLogsProbeOutputBeforeCompletionMarker(): void
+    {
+        $cron = $this->createCron(5);
+
+        $this->config->expects(self::once())->method('isEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('isCronEnabled')->willReturn(true);
+        $this->config->expects(self::once())->method('getCronExpression')->willReturn('*/30 * * * *');
+        $this->config->expects(self::once())->method('getCronAllowedHoursRaw')->willReturn('1, 5, 12');
+        $this->config->expects(self::once())->method('getCronAllowedHours')->willReturn([1, 5, 12]);
+        $this->kickExecutor
+            ->expects(self::once())
+            ->method('execute')
+            ->willReturn([
+                'kick' => 5,
+                'outcome' => 'napping',
+                'messages' => [
+                    'Some non-probe line',
+                    'Probe[indexer_status_snapshot] status=warn msg="before completion"',
+                    'ProbeDetail[indexer_status_snapshot] subsystem=indexer item=before completion status=warn value="value"',
+                ],
+            ]);
+
+        $cron->execute();
+
+        $completionIndex = array_key_last($cron->messages);
+
+        self::assertIsInt($completionIndex);
+        self::assertSame('ChaosDonkey cron completed with kick 5 and outcome napping.', $cron->messages[$completionIndex]);
+
+        $probeIndex = array_search('Probe[indexer_status_snapshot] status=warn msg="before completion"', $cron->messages, true);
+        $probeDetailIndex = array_search('ProbeDetail[indexer_status_snapshot] subsystem=indexer item=before completion status=warn value="value"', $cron->messages, true);
+
+        self::assertIsInt($probeIndex);
+        self::assertIsInt($probeDetailIndex);
+        self::assertLessThan($completionIndex, $probeIndex);
+        self::assertLessThan($completionIndex, $probeDetailIndex);
+    }
+
     public function testItSkipsWhenAllowedHoursConfigIsInvalid(): void
     {
         $cron = $this->createCron(8);

--- a/Test/Unit/Etc/ConfigXmlTest.php
+++ b/Test/Unit/Etc/ConfigXmlTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Etc;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+class ConfigXmlTest extends TestCase
+{
+    public function testProbeDefaultsAreEnabledByDefault(): void
+    {
+        $document = new DOMDocument();
+        $document->load(__DIR__ . '/../../../etc/config.xml');
+
+        $xpath = new DOMXPath($document);
+
+        $probeDefaults = [
+            'enable_indexer_status_snapshot' => '1',
+            'enable_cache_backend_health_snapshot' => '1',
+            'enable_cron_queue_health_snapshot' => '1',
+        ];
+
+        foreach ($probeDefaults as $fieldId => $expectedValue) {
+            $nodes = $xpath->query(sprintf('/config/default/admin/chaos_donkey/%s', $fieldId));
+
+            self::assertNotFalse($nodes);
+            self::assertSame(1, $nodes->length, sprintf('Expected default node for %s to exist', $fieldId));
+
+            self::assertSame(
+                $expectedValue,
+                trim((string) $nodes->item(0)->textContent),
+                sprintf('Expected default value for %s to be %s', $fieldId, $expectedValue)
+            );
+        }
+    }
+}

--- a/Test/Unit/Etc/DiXmlTest.php
+++ b/Test/Unit/Etc/DiXmlTest.php
@@ -9,6 +9,34 @@ use PHPUnit\Framework\TestCase;
 
 class DiXmlTest extends TestCase
 {
+    public function testActionPoolContainsConfiguredProbeActions(): void
+    {
+        $document = new DOMDocument();
+        $document->load(__DIR__ . '/../../../etc/di.xml');
+
+        $xpath = new DOMXPath($document);
+
+        $actionPoolEntries = [
+            'indexer_status_snapshot' => 'ShaunMcManus\\ChaosDonkey\\Action\\IndexerStatusSnapshot',
+            'cache_backend_health_snapshot' => 'ShaunMcManus\\ChaosDonkey\\Action\\CacheBackendHealthSnapshot',
+            'cron_queue_health_snapshot' => 'ShaunMcManus\\ChaosDonkey\\Action\\CronQueueHealthSnapshot',
+        ];
+
+        foreach ($actionPoolEntries as $actionCode => $actionClass) {
+            $nodes = $xpath->query(
+                sprintf(
+                    '/config/type[@name="ShaunMcManus\\ChaosDonkey\\Model\\ActionPool"]/arguments/argument[@name="actions"]'
+                    . '/item[@name="%s" and @xsi:type="object" and normalize-space(text())="%s"]',
+                    $actionCode,
+                    $actionClass
+                )
+            );
+
+            self::assertNotFalse($nodes);
+            self::assertSame(1, $nodes->length, sprintf('Expected ActionPool item %s to be configured', $actionCode));
+        }
+    }
+
     public function testClockInterfacePreferencePointsToSystemClock(): void
     {
         $document = new DOMDocument();

--- a/Test/Unit/Etc/DiXmlTest.php
+++ b/Test/Unit/Etc/DiXmlTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Etc;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+class DiXmlTest extends TestCase
+{
+    public function testClockInterfacePreferencePointsToSystemClock(): void
+    {
+        $document = new DOMDocument();
+        $document->load(__DIR__ . '/../../../etc/di.xml');
+
+        $xpath = new DOMXPath($document);
+        $nodes = $xpath->query(
+            '/config/preference[@for="ShaunMcManus\\ChaosDonkey\\Model\\Probe\\ClockInterface" '
+            . 'and @type="ShaunMcManus\\ChaosDonkey\\Model\\Probe\\SystemClock"]'
+        );
+
+        self::assertNotFalse($nodes);
+        self::assertSame(1, $nodes->length);
+    }
+}

--- a/Test/Unit/Etc/SystemXmlTest.php
+++ b/Test/Unit/Etc/SystemXmlTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Etc;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SystemXmlTest extends TestCase
+{
+    #[DataProvider('probeFieldProvider')]
+    public function testProbeTogglesExistAndUseExpectedDefaultsAndSource(
+        string $fieldId,
+        string $expectedLabel,
+        string $expectedComment
+    ): void {
+        $document = new DOMDocument();
+        $document->load(__DIR__ . '/../../../etc/adminhtml/system.xml');
+
+        $xpath = new DOMXPath($document);
+        $nodes = $xpath->query(sprintf(
+            '/config/system/section[@id="admin"]/group[@id="chaos_donkey"]/field[@id="%s"]',
+            $fieldId
+        ));
+
+        self::assertNotFalse($nodes);
+        self::assertSame(1, $nodes->length, sprintf('Expected field %s to be defined', $fieldId));
+
+        $field = $nodes->item(0);
+
+        self::assertInstanceOf(\DOMElement::class, $field);
+        self::assertSame('select', $field->getAttribute('type'));
+        self::assertSame('1', $field->getAttribute('showInDefault'));
+        self::assertSame('0', $field->getAttribute('showInWebsite'));
+        self::assertSame('0', $field->getAttribute('showInStore'));
+
+        $labelNodes = $xpath->query('label', $field);
+        self::assertNotFalse($labelNodes);
+        self::assertSame(1, $labelNodes->length);
+        self::assertSame($expectedLabel, trim((string) $labelNodes->item(0)->textContent));
+
+        $sourceNodes = $xpath->query('source_model', $field);
+        self::assertNotFalse($sourceNodes);
+        self::assertSame(1, $sourceNodes->length);
+        self::assertSame('Magento\\Config\\Model\\Config\\Source\\Yesno', trim((string) $sourceNodes->item(0)->textContent));
+
+        $commentNodes = $xpath->query('comment', $field);
+        self::assertNotFalse($commentNodes);
+        self::assertSame(1, $commentNodes->length);
+        self::assertSame($expectedComment, trim((string) $commentNodes->item(0)->textContent));
+    }
+
+    public static function probeFieldProvider(): array
+    {
+        return [
+            'indexer status snapshot' => [
+                'enable_indexer_status_snapshot',
+                'Enable Indexer Status Snapshot',
+                'When enabled, the command can trigger an indexer status snapshot probe.',
+            ],
+            'cache backend health snapshot' => [
+                'enable_cache_backend_health_snapshot',
+                'Enable Cache Backend Health Snapshot',
+                'When enabled, the command can trigger a cache backend health probe.',
+            ],
+            'cron queue health snapshot' => [
+                'enable_cron_queue_health_snapshot',
+                'Enable Cron/Queue Health Snapshot',
+                'When enabled, the command can trigger a cron and queue health probe.',
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -70,6 +70,45 @@ class ConfigTest extends TestCase
         self::assertTrue($config->isGraphQlPipelineStressEnabled());
     }
 
+    public function testItReadsIndexerStatusSnapshotEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_INDEXER_STATUS_SNAPSHOT, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isIndexerStatusSnapshotEnabled());
+    }
+
+    public function testItReadsCacheBackendHealthSnapshotEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_CACHE_BACKEND_HEALTH_SNAPSHOT, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isCacheBackendHealthSnapshotEnabled());
+    }
+
+    public function testItReadsCronQueueHealthSnapshotEnabledFlagFromExpectedPath(): void
+    {
+        $this->scopeConfig
+            ->expects(self::once())
+            ->method('isSetFlag')
+            ->with(Config::CONFIG_PATH_ENABLE_CRON_QUEUE_HEALTH_SNAPSHOT, 'default', null)
+            ->willReturn(true);
+
+        $config = new Config($this->scopeConfig);
+
+        self::assertTrue($config->isCronQueueHealthSnapshotEnabled());
+    }
+
     public function testItReadsCronEnabledFlagFromExpectedPath(): void
     {
         $this->scopeConfig
@@ -266,6 +305,18 @@ class ConfigTest extends TestCase
             'graphql pipeline stress' => [
                 'graphql_pipeline_stress',
                 Config::CONFIG_PATH_ENABLE_GRAPHQL_PIPELINE_STRESS,
+            ],
+            'indexer status snapshot' => [
+                'indexer_status_snapshot',
+                Config::CONFIG_PATH_ENABLE_INDEXER_STATUS_SNAPSHOT,
+            ],
+            'cache backend health snapshot' => [
+                'cache_backend_health_snapshot',
+                Config::CONFIG_PATH_ENABLE_CACHE_BACKEND_HEALTH_SNAPSHOT,
+            ],
+            'cron queue health snapshot' => [
+                'cron_queue_health_snapshot',
+                Config::CONFIG_PATH_ENABLE_CRON_QUEUE_HEALTH_SNAPSHOT,
             ],
         ];
     }

--- a/Test/Unit/Model/KickExecutorTest.php
+++ b/Test/Unit/Model/KickExecutorTest.php
@@ -43,12 +43,15 @@ class KickExecutorTest extends TestCase
                 return new ChaosActionResult('cache_flush', 'Cache flush completed');
             });
 
-        $this->config->expects(self::exactly(3))
+        $this->config->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturnMap([
                 ['reindex_all', true],
                 ['cache_flush', true],
                 ['graphql_pipeline_stress', true],
+                ['indexer_status_snapshot', true],
+                ['cache_backend_health_snapshot', true],
+                ['cron_queue_health_snapshot', true],
             ]);
         $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
         $this->resolver->expects(self::once())->method('resolve')->with(3)->willReturn('cache_flush');
@@ -75,21 +78,24 @@ class KickExecutorTest extends TestCase
         ], $result['messages']);
     }
 
-    public function testItRerollsDisabledActionOutcomeAndPersistsFinalOutcome(): void
+    public function testItRerollsDisabledProbeOutcomeAndPersistsFinalOutcome(): void
     {
         $action = $this->createStub(ChaosActionInterface::class);
         $action->method('execute')->willReturn(new ChaosActionResult('cache_flush', 'Cache flush completed'));
 
-        $this->config->expects(self::exactly(3))
+        $this->config->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturnMap([
                 ['reindex_all', false],
                 ['cache_flush', true],
                 ['graphql_pipeline_stress', true],
+                ['indexer_status_snapshot', false],
+                ['cache_backend_health_snapshot', true],
+                ['cron_queue_health_snapshot', true],
             ]);
         $this->kickRoller->expects(self::exactly(2))
             ->method('rollD20')
-            ->willReturnOnConsecutiveCalls(2, 3);
+            ->willReturnOnConsecutiveCalls(5, 3);
         $resolvedRolls = [];
         $this->resolver->expects(self::exactly(2))
             ->method('resolve')
@@ -97,7 +103,7 @@ class KickExecutorTest extends TestCase
                 $resolvedRolls[] = $kick;
 
                 return match ($kick) {
-                    2 => 'reindex_all',
+                    5 => 'indexer_status_snapshot',
                     3 => 'cache_flush',
                 };
             });
@@ -110,7 +116,7 @@ class KickExecutorTest extends TestCase
         $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $result = $executor->execute();
 
-        self::assertSame([2, 3], $resolvedRolls);
+        self::assertSame([5, 3], $resolvedRolls);
         self::assertSame(3, $result['kick']);
         self::assertSame('cache_flush', $result['outcome']);
         self::assertSame([
@@ -121,7 +127,7 @@ class KickExecutorTest extends TestCase
 
     public function testItWarnsOnceWhenAllActionsDisabledAndExecutesNonActionOutcome(): void
     {
-        $this->config->expects(self::exactly(3))
+        $this->config->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturn(false);
         $this->kickRoller->expects(self::exactly(4))
@@ -153,38 +159,81 @@ class KickExecutorTest extends TestCase
         self::assertSame(1, $result['kick']);
         self::assertSame('critical_failure', $result['outcome']);
         self::assertSame([
-            'All configured chaos actions are disabled. Rolling non-action outcomes only.',
+            'All configured chaos actions/probes are disabled. Rolling non-action outcomes only.',
             'ChaosDonkeyKick kicks your Magento. You rolled a 1',
             'Critical Failure! Better check all of your donkeys.',
         ], $result['messages']);
     }
 
-    public function testItFallsBackToNappingAfterMaxAttempts(): void
+    public function testItFallsBackToNappingAfterMaxAttemptsWhenProbesRemainDisabled(): void
     {
-        $this->config->expects(self::exactly(3))
+        $this->config->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturnMap([
                 ['reindex_all', false],
                 ['cache_flush', true],
-                ['graphql_pipeline_stress', true],
+                ['graphql_pipeline_stress', false],
+                ['indexer_status_snapshot', false],
+                ['cache_backend_health_snapshot', false],
+                ['cron_queue_health_snapshot', false],
             ]);
-        $this->kickRoller->expects(self::exactly(20))->method('rollD20')->willReturn(2);
-        $this->resolver->expects(self::exactly(20))->method('resolve')->with(2)->willReturn('reindex_all');
+        $this->kickRoller->expects(self::exactly(20))->method('rollD20')->willReturn(5);
+        $this->resolver->expects(self::exactly(20))->method('resolve')->with(5)->willReturn('indexer_status_snapshot');
         $this->actionPool->expects(self::once())->method('get')->with('napping')->willReturn(null);
 
         $this->stateWriter->expects(self::once())->method('saveLastRun');
-        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(2);
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(5);
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('napping');
 
         $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
         $result = $executor->execute();
 
-        self::assertSame(2, $result['kick']);
+        self::assertSame(5, $result['kick']);
         self::assertSame('napping', $result['outcome']);
         self::assertSame([
             'Max reroll attempts reached. Falling back to napping.',
-            'ChaosDonkeyKick kicks your Magento. You rolled a 2',
+            'ChaosDonkeyKick kicks your Magento. You rolled a 5',
             'The donkeys are napping',
+        ], $result['messages']);
+    }
+
+    public function testItOmitsEmptyActionSummaryWithoutOutcomeBranching(): void
+    {
+        $action = $this->createStub(ChaosActionInterface::class);
+        $action
+            ->method('execute')
+            ->willReturnCallback(static function (BufferedOutput $output): ChaosActionResult {
+                $output->writeln('Probe output');
+
+                return new ChaosActionResult('cache_backend_health_snapshot', '');
+            });
+
+        $this->config->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', true],
+                ['cache_flush', false],
+                ['graphql_pipeline_stress', false],
+                ['indexer_status_snapshot', false],
+                ['cache_backend_health_snapshot', true],
+                ['cron_queue_health_snapshot', false],
+            ]);
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(6);
+        $this->resolver->expects(self::once())->method('resolve')->with(6)->willReturn('cache_backend_health_snapshot');
+        $this->actionPool->expects(self::once())->method('get')->with('cache_backend_health_snapshot')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(6);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_backend_health_snapshot');
+
+        $executor = new KickExecutor($this->config, $this->actionPool, $this->resolver, $this->stateWriter, $this->kickRoller);
+        $result = $executor->execute();
+
+        self::assertSame(6, $result['kick']);
+        self::assertSame('cache_backend_health_snapshot', $result['outcome']);
+        self::assertSame([
+            'ChaosDonkeyKick kicks your Magento. You rolled a 6',
+            'Probe output',
         ], $result['messages']);
     }
 }

--- a/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
+++ b/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
@@ -22,7 +22,8 @@ class ProbeOutputFormatterTest extends TestCase
         $snapshot = new ProbeSnapshot(
             'db_ping',
             'warn',
-            'Database response too slow'
+            'Database response too slow',
+            []
         );
 
         self::assertSame(
@@ -36,7 +37,8 @@ class ProbeOutputFormatterTest extends TestCase
         $snapshot = new ProbeSnapshot(
             'db_ping',
             'warn',
-            'Service "endpoint"' . "\n" . 'status 500'
+            'Service "endpoint"' . "\n" . 'status 500',
+            []
         );
 
         $expected = 'Probe[db_ping] status=warn msg=' . json_encode(
@@ -155,7 +157,8 @@ class ProbeOutputFormatterTest extends TestCase
         $snapshot = new ProbeSnapshot(
             'cache',
             'ok',
-            'All cache checks passed'
+            'All cache checks passed',
+            []
         );
 
         self::assertSame(

--- a/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
+++ b/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
@@ -31,6 +31,25 @@ class ProbeOutputFormatterTest extends TestCase
         );
     }
 
+    public function testFormatSummaryEscapesQuotesAndNewlines(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'db_ping',
+            'warn',
+            'Service "endpoint"' . "\n" . 'status 500'
+        );
+
+        $expected = 'Probe[db_ping] status=warn msg=' . json_encode(
+            'Service "endpoint"' . "\n" . 'status 500',
+            JSON_UNESCAPED_UNICODE
+        );
+
+        self::assertSame(
+            $expected,
+            $this->formatter->formatSummary($snapshot)
+        );
+    }
+
     public function testFormatTopDetailsSortsBySeveritySubsystemItemWithCap(): void
     {
         $snapshot = new ProbeSnapshot(
@@ -63,6 +82,23 @@ class ProbeOutputFormatterTest extends TestCase
 
         self::assertSame(
             'Probe[storage_readiness] subsystem=filesystem item=readable status=ok msg="All mounts readable"',
+            $this->formatter->formatDetail('storage_readiness', $detail)
+        );
+    }
+
+    public function testFormatDetailCanonicalEnvelopeEscapesQuotesAndNewlines(): void
+    {
+        $detail = new ProbeDetailRow('filesystem', 'readable', 'ok', 'Check "permissions"' . "\n" . 'for /var');
+
+        $expected = 'Probe[storage_readiness] subsystem=filesystem item=readable status=ok msg=' . json_encode(
+            'Check "permissions"' . "\n" . 'for /var',
+            JSON_UNESCAPED_UNICODE
+        );
+
+        $expected = str_replace('\\/', '/', $expected);
+
+        self::assertSame(
+            $expected,
             $this->formatter->formatDetail('storage_readiness', $detail)
         );
     }
@@ -111,6 +147,20 @@ class ProbeOutputFormatterTest extends TestCase
             . "Probe[cache] subsystem=queue item=worker status=unavailable msg=\"fourth detail\"\n"
             . "Probe[cache] subsystem=search item=query status=warn msg=\"fifth detail\"",
             $this->formatter->formatTopDetails($snapshot)
+        );
+    }
+
+    public function testFormatLinesWithNoDetailsReturnsSummaryOnly(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'cache',
+            'ok',
+            'All cache checks passed'
+        );
+
+        self::assertSame(
+            'Probe[cache] status=ok msg="All cache checks passed"',
+            $this->formatter->formatLines($snapshot)
         );
     }
 }

--- a/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
+++ b/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model\Probe;
+
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeDetailRow;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeOutputFormatter;
+use ShaunMcManus\ChaosDonkey\Model\Probe\ProbeSnapshot;
+
+class ProbeOutputFormatterTest extends TestCase
+{
+    private ProbeOutputFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new ProbeOutputFormatter();
+    }
+
+    public function testFormatSummary(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'db_ping',
+            'warn',
+            'Database response too slow'
+        );
+
+        self::assertSame(
+            'Probe[db_ping] status=warn msg="Database response too slow"',
+            $this->formatter->formatSummary($snapshot)
+        );
+    }
+
+    public function testFormatTopDetailsSortsBySeveritySubsystemItemWithCap(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'system_health',
+            'warn',
+            'System has issues',
+            [
+                new ProbeDetailRow('storage', 'free', 'ok', 'has space'),
+                new ProbeDetailRow('cache', 'status', 'warn', 'flush needed'),
+                new ProbeDetailRow('index', 'status', 'unavailable', 'indexer missing'),
+                new ProbeDetailRow('storage', 'iops', 'warn', 'slow reads'),
+                new ProbeDetailRow('cache', 'pool', 'unknown', 'warmup needed'),
+                new ProbeDetailRow('search', 'status', 'ok', 'ok status'),
+            ]
+        );
+
+        self::assertSame(
+            "Probe[system_health] subsystem=cache item=status status=warn msg=\"flush needed\"\n"
+            . "Probe[system_health] subsystem=storage item=iops status=warn msg=\"slow reads\"\n"
+            . "Probe[system_health] subsystem=index item=status status=unavailable msg=\"indexer missing\"\n"
+            . "Probe[system_health] subsystem=cache item=pool status=unknown msg=\"warmup needed\"\n"
+            . "Probe[system_health] subsystem=search item=status status=ok msg=\"ok status\"",
+            $this->formatter->formatTopDetails($snapshot)
+        );
+    }
+
+    public function testFormatDetailCanonicalEnvelope(): void
+    {
+        $detail = new ProbeDetailRow('filesystem', 'readable', 'ok', 'All mounts readable');
+
+        self::assertSame(
+            'Probe[storage_readiness] subsystem=filesystem item=readable status=ok msg="All mounts readable"',
+            $this->formatter->formatDetail('storage_readiness', $detail)
+        );
+    }
+
+    public function testFormatLinesBeginsWithSummary(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'cache',
+            'warn',
+            'Some cache components need attention',
+            [
+                new ProbeDetailRow('cache', 'frontend', 'warn', 'flush queue full'),
+                new ProbeDetailRow('database', 'replica', 'ok', 'lagging but within range'),
+            ]
+        );
+
+        self::assertSame(
+            "Probe[cache] status=warn msg=\"Some cache components need attention\"\n"
+            . "Probe[cache] subsystem=cache item=frontend status=warn msg=\"flush queue full\"\n"
+            . "Probe[cache] subsystem=database item=replica status=ok msg=\"lagging but within range\"",
+            $this->formatter->formatLines($snapshot)
+        );
+    }
+
+    public function testFormatTopDetailsRespectsPreserveIncomingOrderWhenRequested(): void
+    {
+        $snapshot = new ProbeSnapshot(
+            'cache',
+            'warn',
+            'some details',
+            [
+                new ProbeDetailRow('search', 'indexer', 'ok', 'first detail'),
+                new ProbeDetailRow('cache', 'backend', 'warn', 'second detail'),
+                new ProbeDetailRow('database', 'connection', 'unknown', 'third detail'),
+                new ProbeDetailRow('queue', 'worker', 'unavailable', 'fourth detail'),
+                new ProbeDetailRow('search', 'query', 'warn', 'fifth detail'),
+                new ProbeDetailRow('other', 'item', 'ok', 'sixth detail'),
+            ],
+            true
+        );
+
+        self::assertSame(
+            "Probe[cache] subsystem=search item=indexer status=ok msg=\"first detail\"\n"
+            . "Probe[cache] subsystem=cache item=backend status=warn msg=\"second detail\"\n"
+            . "Probe[cache] subsystem=database item=connection status=unknown msg=\"third detail\"\n"
+            . "Probe[cache] subsystem=queue item=worker status=unavailable msg=\"fourth detail\"\n"
+            . "Probe[cache] subsystem=search item=query status=warn msg=\"fifth detail\"",
+            $this->formatter->formatTopDetails($snapshot)
+        );
+    }
+}

--- a/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
+++ b/Test/Unit/Model/Probe/ProbeOutputFormatterTest.php
@@ -67,11 +67,11 @@ class ProbeOutputFormatterTest extends TestCase
         );
 
         self::assertSame(
-            "Probe[system_health] subsystem=cache item=status status=warn msg=\"flush needed\"\n"
-            . "Probe[system_health] subsystem=storage item=iops status=warn msg=\"slow reads\"\n"
-            . "Probe[system_health] subsystem=index item=status status=unavailable msg=\"indexer missing\"\n"
-            . "Probe[system_health] subsystem=cache item=pool status=unknown msg=\"warmup needed\"\n"
-            . "Probe[system_health] subsystem=search item=status status=ok msg=\"ok status\"",
+            "ProbeDetail[system_health] subsystem=cache item=status status=warn value=\"flush needed\"\n"
+            . "ProbeDetail[system_health] subsystem=storage item=iops status=warn value=\"slow reads\"\n"
+            . "ProbeDetail[system_health] subsystem=index item=status status=unavailable value=\"indexer missing\"\n"
+            . "ProbeDetail[system_health] subsystem=cache item=pool status=unknown value=\"warmup needed\"\n"
+            . "ProbeDetail[system_health] subsystem=search item=status status=ok value=\"ok status\"",
             $this->formatter->formatTopDetails($snapshot)
         );
     }
@@ -81,7 +81,7 @@ class ProbeOutputFormatterTest extends TestCase
         $detail = new ProbeDetailRow('filesystem', 'readable', 'ok', 'All mounts readable');
 
         self::assertSame(
-            'Probe[storage_readiness] subsystem=filesystem item=readable status=ok msg="All mounts readable"',
+            'ProbeDetail[storage_readiness] subsystem=filesystem item=readable status=ok value="All mounts readable"',
             $this->formatter->formatDetail('storage_readiness', $detail)
         );
     }
@@ -90,7 +90,7 @@ class ProbeOutputFormatterTest extends TestCase
     {
         $detail = new ProbeDetailRow('filesystem', 'readable', 'ok', 'Check "permissions"' . "\n" . 'for /var');
 
-        $expected = 'Probe[storage_readiness] subsystem=filesystem item=readable status=ok msg=' . json_encode(
+        $expected = 'ProbeDetail[storage_readiness] subsystem=filesystem item=readable status=ok value=' . json_encode(
             'Check "permissions"' . "\n" . 'for /var',
             JSON_UNESCAPED_UNICODE
         );
@@ -117,8 +117,8 @@ class ProbeOutputFormatterTest extends TestCase
 
         self::assertSame(
             "Probe[cache] status=warn msg=\"Some cache components need attention\"\n"
-            . "Probe[cache] subsystem=cache item=frontend status=warn msg=\"flush queue full\"\n"
-            . "Probe[cache] subsystem=database item=replica status=ok msg=\"lagging but within range\"",
+            . "ProbeDetail[cache] subsystem=cache item=frontend status=warn value=\"flush queue full\"\n"
+            . "ProbeDetail[cache] subsystem=database item=replica status=ok value=\"lagging but within range\"",
             $this->formatter->formatLines($snapshot)
         );
     }
@@ -141,11 +141,11 @@ class ProbeOutputFormatterTest extends TestCase
         );
 
         self::assertSame(
-            "Probe[cache] subsystem=search item=indexer status=ok msg=\"first detail\"\n"
-            . "Probe[cache] subsystem=cache item=backend status=warn msg=\"second detail\"\n"
-            . "Probe[cache] subsystem=database item=connection status=unknown msg=\"third detail\"\n"
-            . "Probe[cache] subsystem=queue item=worker status=unavailable msg=\"fourth detail\"\n"
-            . "Probe[cache] subsystem=search item=query status=warn msg=\"fifth detail\"",
+            "ProbeDetail[cache] subsystem=search item=indexer status=ok value=\"first detail\"\n"
+            . "ProbeDetail[cache] subsystem=cache item=backend status=warn value=\"second detail\"\n"
+            . "ProbeDetail[cache] subsystem=database item=connection status=unknown value=\"third detail\"\n"
+            . "ProbeDetail[cache] subsystem=queue item=worker status=unavailable value=\"fourth detail\"\n"
+            . "ProbeDetail[cache] subsystem=search item=query status=warn value=\"fifth detail\"",
             $this->formatter->formatTopDetails($snapshot)
         );
     }

--- a/Test/Unit/Model/RollOutcomeResolverTest.php
+++ b/Test/Unit/Model/RollOutcomeResolverTest.php
@@ -15,8 +15,11 @@ class RollOutcomeResolverTest extends TestCase
         self::assertSame('reindex_all', $resolver->resolve(2));
         self::assertSame('cache_flush', $resolver->resolve(3));
         self::assertSame('graphql_pipeline_stress', $resolver->resolve(4));
+        self::assertSame('indexer_status_snapshot', $resolver->resolve(5));
+        self::assertSame('cache_backend_health_snapshot', $resolver->resolve(6));
+        self::assertSame('cron_queue_health_snapshot', $resolver->resolve(7));
         self::assertSame('critical_failure', $resolver->resolve(1));
         self::assertSame('critical_success', $resolver->resolve(20));
-        self::assertSame('napping', $resolver->resolve(6));
+        self::assertSame('napping', $resolver->resolve(19));
     }
 }

--- a/docs/superpowers/specs/2026-03-29-chaos-actions-phase-3-read-only-probes-design.md
+++ b/docs/superpowers/specs/2026-03-29-chaos-actions-phase-3-read-only-probes-design.md
@@ -25,6 +25,19 @@ Expand ChaosDonkey with read-only operational probes that improve operator visib
 - Config controls: per-probe admin enable toggles
 - Architectural direction: probe abstraction layer (Magento best-practice oriented)
 
+## Deterministic Roll Mapping (Phase 3)
+To keep planning and tests deterministic, Phase 3 assigns fixed D20 values:
+
+| Roll | Outcome code |
+|------|--------------|
+| `5`  | `indexer_status_snapshot` |
+| `6`  | `cache_backend_health_snapshot` |
+| `7`  | `cron_queue_health_snapshot` |
+
+All existing mappings for `1`, `2`, `3`, `4`, and `20` remain unchanged.
+
+These three values are selected from current non-action slots to satisfy the “replace napping slots” decision.
+
 ## Architecture
 Phase 3 extends the current action framework by introducing a small probe abstraction while keeping probes as first-class kick outcomes.
 
@@ -36,8 +49,8 @@ Core principles:
 
 Planned shape:
 - Existing `ChaosActionInterface` remains the execution contract used by the action pool.
-- Add `Api/ProbeActionInterface` as a probe-specific marker/contract for read-only action semantics and future extensibility.
-- Probe actions implement both interfaces.
+- No additional probe-specific interface in Phase 3 (YAGNI).
+- Probe actions implement only `ChaosActionInterface` and reuse shared probe helper services.
 - Add shared probe output formatting service for consistent “summary + top details” output.
 
 This balances immediate delivery with maintainability if probe count grows in later phases.
@@ -45,42 +58,208 @@ This balances immediate delivery with maintainability if probe count grows in la
 ## Components and Responsibilities
 
 ### New interfaces/services
-- `Api/ProbeActionInterface.php`
-  - Defines probe-specific contract/semantics for read-only probes.
-  - Keeps probe concerns explicit without changing existing action pool behavior.
-
 - `Model/Probe/ProbeOutputFormatter.php`
   - Shared formatter for concise operator output.
+  - Public API:
+    - `formatSummary(ProbeSnapshot $snapshot): string`
+    - `formatTopDetails(ProbeSnapshot $snapshot, int $limit = 5): array<string>`
+    - `formatLines(ProbeSnapshot $snapshot, int $limit = 5): array<string>`
+  - Ownership rule:
+    - `ProbeSnapshot.summary` is the canonical human-readable summary content.
+    - `formatSummary()` only applies canonical envelope/prefix; it does not invent alternate summaries.
+  - Deterministic top-details ordering rule:
+    - sort by severity (`warn` > `unavailable` > `unknown` > `ok`)
+    - then by `subsystem` ASC
+    - then by `item` ASC
+    - then take first `5`
+    - notable-row guarantee:
+      - include non-`ok` rows before any `ok` rows
+      - include `ok` rows only when cap remains
+  - Fixed-order override rule:
+    - probes may declare fixed-order detail output; when set, formatter preserves provided order and skips severity sorting.
   - Produces a stable shape:
     - summary headline
     - bounded top details (warnings, notable counters/items)
+  - Canonical line formats:
+    - summary: `Probe[<probe_code>] status=<status> msg="<summary>"`
+    - detail: `ProbeDetail[<probe_code>] subsystem=<subsystem> item=<item> status=<status> value="<value>"`
+
+- `Model/Probe/ClockInterface.php`
+  - Method:
+    - `nowUtc(): \DateTimeImmutable`
+  - Scope:
+    - single time source for cron/queue lookback calculations and tests.
+
+- `Model/Probe/SystemClock.php`
+  - Default implementation of `ClockInterface` for production runtime.
+  - Returns UTC `DateTimeImmutable` values.
+
+- `Model/Probe/ProbeSnapshot.php`
+  - Lightweight DTO/value object for probe results.
+  - Fields:
+    - `probeCode` (string)
+    - `status` (`ok|warn|unknown|unavailable`)
+    - `summary` (string)
+    - `details` (array of `ProbeDetailRow`)
+
+- `Model/Probe/ProbeDetailRow.php`
+  - Common normalized detail row shape shared by all probes.
+  - Fields:
+    - `subsystem` (string)
+    - `item` (string)
+    - `value` (string)
+    - `status` (`ok|warn|unknown|unavailable`)
 
 ### New actions
 - `Action/IndexerStatusSnapshot.php`
   - Read-only snapshot of indexer mode/state indicators.
+  - Required summary fields:
+    - total indexer count
+    - invalid/reindex-required count
+    - scheduled vs realtime count (if available)
+  - Detail rows use common `ProbeDetailRow` fields:
+    - `subsystem=indexer`, `item=<indexer_id>`, `value=state=<state>;mode=<mode|unavailable>`, `status=<mapped status>`
+  - Data sources:
+    - `Magento\Indexer\Model\IndexerRegistry` (+ indexer state APIs)
+    - `Magento\Indexer\Model\Indexer\CollectionFactory` (deterministic full indexer enumeration)
+  - Status rules:
+    - row status `warn` when indexer state indicates invalid/reindex required (takes precedence)
+    - row status `unknown` when mode is unavailable but state is otherwise readable
+    - row status `ok` otherwise
+    - probe status `unknown` if indexer enumeration/state read fails
+    - probe status `warn` when invalid/reindex-required count > 0 (takes precedence over unknown mode rows)
+    - probe status `unknown` when invalid count is 0 and one or more mode values are unavailable
+    - probe status `ok` when invalid count is 0 and all mode values are readable
+  - Mode fallback rule:
+    - if mode cannot be resolved for any indexer, emit `modes=unavailable` in summary and mark affected rows `status=unknown`.
+  - Canonical summary template:
+    - normal: `<total> indexers, <invalid> need reindex, modes: schedule=<scheduled>, realtime=<realtime>`
+    - mode-unavailable: `<total> indexers, <invalid> need reindex, modes=unavailable`
+  - Canonical detail value template:
+    - `state=<state>;mode=<mode|unavailable>`
 
 - `Action/CacheBackendHealthSnapshot.php`
   - Read-only snapshot of cache type/backend health signals.
+  - Required summary fields:
+    - total cache type count
+    - enabled cache type count
+    - backend adapter resolution status
+  - Detail rows use common `ProbeDetailRow` fields:
+    - one row per cache type: `subsystem=cache`, `item=<cache_type>`, `value=enabled=<true|false>`, `status=ok`
+    - one backend row: `subsystem=cache_backend`, `item=default_frontend`, `value=<backend class basename>`, `status=ok|warn|unknown`
+  - Data sources:
+    - `Magento\Framework\App\Cache\TypeListInterface`
+    - `Magento\Framework\App\Cache\Frontend\Pool` (exact required DI boundary for backend resolution)
+  - Default frontend identification rule:
+    - resolve frontend id `default` only
+    - if `default` frontend is not resolvable, backend status becomes `unknown`
+  - Read-only constraint for backend checks:
+    - metadata/instance-resolution only (no writes, no flushes, no mutation methods)
+  - Backend resolution-failure definition:
+    - `default` frontend exists but resolving backend class basename throws exception/throwable
+  - Status rules:
+    - `ok`: cache types are discoverable and default frontend backend resolves without exception
+    - `warn`: cache types are discoverable, `default` frontend exists, but backend resolution fails
+    - `unknown`: cache metadata cannot be read safely OR `default` frontend cannot be resolved
+  - Canonical summary template:
+    - ok: `<total> cache types, <enabled> enabled, backend adapter=<adapter_label>`
+    - warn: `<total> cache types, <enabled> enabled, backend adapter resolution degraded`
+    - unknown: `cache snapshot unavailable`
+  - Canonical detail value templates:
+    - cache row: `enabled=<true|false>`
+    - backend row: `<adapter_label|resolution_failed|unavailable>`
+  - Adapter label safety rule:
+    - use sanitized backend class basename label only (`[a-z0-9_]+`), never hostnames/connection strings.
 
 - `Action/CronQueueHealthSnapshot.php`
   - Read-only snapshot for cron/queue health indicators available within module constraints.
+  - Scope boundary: one probe class with two clearly separated collectors internally:
+    - cron collector (required)
+    - queue collector (optional when queue signals are available)
+  - Required summary fields:
+    - cron status headline (healthy/degraded/unknown)
+    - queue status headline (healthy/degraded/unknown/unavailable)
+  - Detail row granularity (deterministic):
+    - `subsystem=cron`, `item=failures_last_60m`, `value=<count>`, `status=ok|warn`
+    - `subsystem=cron`, `item=pending_older_15m`, `value=<count>`, `status=ok|warn`
+    - `subsystem=queue`, `item=tables_present`, `value=true|false`, `status=ok|unavailable`
+    - `subsystem=queue`, `item=activity_last_60m`, `value=<count|n/a>`, `status=ok|warn|unavailable|unknown`
+  - Emission rule:
+    - always emit all four detail rows in the fixed order above (never omit rows)
+  - Data sources:
+    - cron: `cron_schedule` via `Magento\Framework\App\ResourceConnection`
+    - queue (optional): tables `queue`, `queue_message`, `queue_message_status` via `ResourceConnection` when present
+  - Partial-table classification rule:
+    - if any required queue table is missing, classify queue as `unavailable` (`tables_present=false`)
+  - Status rules:
+    - cron `ok`: no warning indicators in lookback window
+    - cron `warn`: backlog/failure indicators exceed threshold
+    - cron `unknown`: cron data source unavailable
+    - queue `unavailable`: queue tables absent in current installation
+    - queue `warn`: queue tables present, zero queue activity in lookback, and cron is already in warn state
+    - queue `ok`: queue tables present and queryable
+    - queue `unknown`: queue tables present but query failure/exception occurs
+  - Overall probe status precedence (deterministic):
+    - if cron is `warn` OR queue is `warn` => overall `warn`
+    - else if cron is `unknown` OR queue is `unknown` => overall `unknown`
+    - else if queue is `unavailable` and cron is `ok` => overall `ok` (with queue-unavailable detail row)
+    - else => overall `ok`
+  - Headline mapping (deterministic):
+    - `ok -> healthy`
+    - `warn -> degraded`
+    - `unknown -> unknown`
+    - `unavailable -> unavailable`
+  - Threshold defaults for v1 (config-free):
+    - lookback window: 60 minutes
+    - cron warning indicator A: `count(*)` where `status in ('error','missed')` and `scheduled_at >= now-60m` is `> 0`
+    - cron warning indicator B: `count(*)` where `status='pending'` and `scheduled_at < now-15m` is `> 10`
+    - queue activity signal: `count(*)` from `queue_message_status` where `updated_at >= now-60m`
+  - Canonical summary template:
+    - `cron=<cron_headline>, queue=<queue_headline>, failures_last_60m=<n|n/a>, pending_older_15m=<n|n/a>, activity_last_60m=<n|n/a>`
+  - Canonical detail value templates:
+    - `failures_last_60m`: `<n>`
+    - `pending_older_15m`: `<n>`
+    - `tables_present`: `<true|false>`
+    - `activity_last_60m`: `<n|n/a>`
 
 ### Existing components to extend
 - `etc/di.xml`
   - Register new probe action codes in the action pool map.
+  - Bind clock dependency:
+    - `Model\Probe\ClockInterface` preference => `Model\Probe\SystemClock`
 
 - `Model/RollOutcomeResolver.php`
-  - Add probe outcomes by replacing selected `napping` roll slots.
+  - Add probe outcomes with fixed mapping:
+    - `5 => indexer_status_snapshot`
+    - `6 => cache_backend_health_snapshot`
+    - `7 => cron_queue_health_snapshot`
 
 - `Model/KickExecutor.php`
   - Include probe codes in reroll-eligible action code set.
   - Preserve existing retry limit and fallback behavior.
+  - Result boundary decision:
+    - keep shared executor result message list as the single carrier for both CLI and cron paths
+    - probe actions use existing transport behavior: buffered output lines only (probe summary and details are both emitted to output)
+    - probe actions must return empty `ChaosActionResult` summaries to avoid duplicate `Probe[...]` lines
+    - executor appends, in order: buffered action output lines, then non-empty summary
+    - summary append rule remains generic for all actions: append only when non-empty
+    - executor remains probe-agnostic (no probe-type branching or interface checks)
+
+- `Cron/ChaosDonkeyKickCron.php`
+  - Extend cron execution logging to include probe-only messages from executor-returned message lines (summary + top details), not just start/skip/completion markers.
+  - Probe-only filter rule:
+    - log only lines prefixed with `Probe[` or `ProbeDetail[`
+  - Ordering rule:
+    - log messages in received order, unchanged
 
 - `etc/adminhtml/system.xml`
   - Add per-probe yes/no toggles under `admin/chaos_donkey`.
 
 - `etc/config.xml`
-  - Add defaults for per-probe toggles.
+  - Add defaults for per-probe toggles:
+    - `enable_indexer_status_snapshot=1`
+    - `enable_cache_backend_health_snapshot=1`
+    - `enable_cron_queue_health_snapshot=1`
 
 - `Model/Config.php`
   - Add config path constants + typed accessors.
@@ -97,7 +276,8 @@ Config UX policy:
 - `system.xml` yes/no select fields (`Magento\Config\Model\Config\Source\Yesno`)
 - explicit operational comments for each toggle
 - defaults defined in `etc/config.xml`
-- maintain current scope policy used by module’s operational settings
+- scope: default only (`showInDefault=1`, `showInWebsite=0`, `showInStore=0`)
+- default-on rationale: Phase 3 is read-only and optimized for visibility; operators can disable any probe individually
 
 ## Runtime Data Flow
 1. Kick starts via CLI command or cron-triggered job.
@@ -108,18 +288,67 @@ Config UX policy:
 5. If attempts exhausted:
    - fallback to `napping` (unchanged).
 6. If enabled action/probe selected:
-   - `ActionPool` resolves action service by outcome code.
-   - action executes and emits summary + top details.
+    - `ActionPool` resolves action service by outcome code.
+    - action executes and emits summary + top details.
 7. Existing state persistence (`last_run`, `last_kick`, `last_outcome`) remains unchanged.
+
+Cron output policy:
+- CLI path: full summary + top details rendered to console output.
+- Cron path: consume the same executor result message list, filter to probe-prefixed lines, and log those lines to module logger context.
+- Logging format policy: plain canonical message strings only (no additional structured PSR-3 context required in Phase 3).
+- Logger-prefix rule:
+  - if cron logger helper/channel prepends text, that prefix is transport metadata and not part of canonical probe payload assertions.
+  - tests should assert canonical payload substring presence (not exact full-line equality including transport prefix).
+- Time-source rule:
+  - lookback calculations use injected clock/time provider (not direct `new \DateTimeImmutable()` in probe classes) for deterministic tests.
+  - canonical time basis for DB comparisons: UTC timestamps derived from `ClockInterface::nowUtc()`.
+
+Failure output normalization (deterministic):
+- Indexer enumeration/state failure:
+  - summary: `status=unknown msg="<total|n/a> indexers, <invalid|n/a> need reindex, modes=unavailable"`
+  - detail: `subsystem=indexer item=enumeration status=unknown value="unavailable"`
+- Cache metadata read failure:
+  - summary: `status=unknown msg="cache snapshot unavailable"`
+  - detail: `subsystem=cache item=metadata status=unknown value="unavailable"`
+- Cache backend resolution failure:
+  - summary: `status=warn msg="<total> cache types, <enabled> enabled, backend adapter resolution degraded"`
+  - detail: `subsystem=cache_backend item=default_frontend status=warn value="resolution_failed"`
+- Cron query failure:
+  - summary: `status=<overall_status_from_precedence> msg="cron=unknown, queue=<queue_headline>, failures_last_60m=n/a, pending_older_15m=n/a, activity_last_60m=<n|n/a>"`
+  - detail: `subsystem=cron item=failures_last_60m status=unknown value="n/a"`
+  - detail: `subsystem=cron item=pending_older_15m status=unknown value="n/a"`
+  - detail: `subsystem=queue item=tables_present status=<ok|unavailable> value="<true|false>"`
+  - detail: `subsystem=queue item=activity_last_60m status=<ok|warn|unavailable|unknown> value="<n|n/a>"`
+- Queue tables unavailable:
+  - summary: `status=<overall_status_from_precedence> msg="cron=<cron_headline>, queue=unavailable, failures_last_60m=<n|n/a>, pending_older_15m=<n|n/a>, activity_last_60m=n/a"`
+  - detail: `subsystem=cron item=failures_last_60m status=<ok|warn|unknown> value="<n|n/a>"`
+  - detail: `subsystem=cron item=pending_older_15m status=<ok|warn|unknown> value="<n|n/a>"`
+  - detail: `subsystem=queue item=tables_present status=unavailable value="false"`
+  - detail: `subsystem=queue item=activity_last_60m status=unavailable value="n/a"`
+- Queue query failure:
+  - summary: `status=<overall_status_from_precedence> msg="cron=<cron_headline>, queue=unknown, failures_last_60m=<n|n/a>, pending_older_15m=<n|n/a>, activity_last_60m=n/a"`
+  - detail: `subsystem=cron item=failures_last_60m status=<ok|warn|unknown> value="<n|n/a>"`
+  - detail: `subsystem=cron item=pending_older_15m status=<ok|warn|unknown> value="<n|n/a>"`
+  - detail: `subsystem=queue item=tables_present status=ok value="true"`
+  - detail: `subsystem=queue item=activity_last_60m status=unknown value="n/a"`
 
 ## Error Handling and Safety
 - Probe actions are read-only by contract.
 - Probe failures should degrade gracefully where possible:
   - provide clear warning lines to operator output
   - avoid crashing entire kick flow for recoverable probe-source issues
+- Exception boundary rule:
+  - probe actions must catch probe-source exceptions and normalize to `warn|unknown|unavailable` probe lines.
+  - no executor-level throwable handling changes are required for Phase 3.
 - Keep detail output bounded to avoid log/console noise.
+- Top-detail cap is fixed at `5` rows per probe for both CLI and cron logging.
 - Use PSR-3 logging only for diagnostics that complement console output.
 - Do not leak sensitive backend details in probe output.
+- `ChaosActionResult::isSuccess()` mapping for probe actions:
+  - probe status `ok` => `true`
+  - probe status `warn` => `true`
+  - probe status `unknown` => `false`
+  - probe status `unavailable` => `true`
 
 ## Testing Strategy
 
@@ -127,18 +356,32 @@ Config UX policy:
 - `Test/Unit/Action/IndexerStatusSnapshotTest.php`
 - `Test/Unit/Action/CacheBackendHealthSnapshotTest.php`
 - `Test/Unit/Action/CronQueueHealthSnapshotTest.php`
+- `Test/Unit/Model/Probe/ProbeOutputFormatterTest.php`
 
 Coverage focus:
 - summary output correctness
 - top-detail inclusion/capping
 - graceful handling for unavailable/partial data
+- deterministic overall-status precedence for mixed cron/queue states
+- canonical line formatting and deterministic ordering
+
+Test seam/stub requirements:
+- Add/extend local test stubs (or thin adapters) for:
+  - `Magento\Framework\App\ResourceConnection`
+  - `Magento\Framework\App\Cache\Frontend\Pool`
+  - `Magento\Framework\App\Cache\TypeListInterface`
+  - `Magento\Indexer\Model\IndexerRegistry`
+  - `Magento\Indexer\Model\Indexer\CollectionFactory`
+- Implementation plan must include either:
+  - direct stub additions for these dependencies, or
+  - wrapper adapters with narrower contracts to reduce stub surface
 
 ### Unit tests to update
 - `Test/Unit/Model/ConfigTest.php`
   - new toggle accessors/constants and action-code enable checks
 
 - `Test/Unit/Model/RollOutcomeResolverTest.php`
-  - new probe roll mappings
+  - explicit assertions for roll values `5/6/7`
 
 - `Test/Unit/Model/KickExecutorTest.php`
   - reroll behavior for disabled probes
@@ -147,8 +390,61 @@ Coverage focus:
 - `Test/Unit/Console/Command/ChaosDonkeyKickTest.php` (as needed)
   - probe output surfaced through existing command pipeline
 
+- `Test/Unit/Cron/ChaosDonkeyKickCronTest.php`
+  - cron logs include probe summaries/details forwarded from executor result messages (bounded to top 5)
+
+### Example output shape (normative)
+CLI sample:
+- `Probe[indexer_status_snapshot] status=warn msg="42 indexers, 3 need reindex, modes: schedule=35, realtime=7"`
+- `ProbeDetail[indexer_status_snapshot] subsystem=indexer item=catalogrule_rule status=warn value="state=invalid;mode=schedule"`
+
+Cron logger sample:
+- `Probe[indexer_status_snapshot] status=warn msg="42 indexers, 3 need reindex, modes: schedule=35, realtime=7"`
+- `ProbeDetail[indexer_status_snapshot] subsystem=indexer item=catalogrule_rule status=warn value="state=invalid;mode=schedule"`
+
+Cache sample:
+- `Probe[cache_backend_health_snapshot] status=ok msg="14 cache types, 14 enabled, backend adapter=redis"`
+- `ProbeDetail[cache_backend_health_snapshot] subsystem=cache_backend item=default_frontend status=ok value="redis"`
+
+Cron/queue sample:
+- `Probe[cron_queue_health_snapshot] status=warn msg="cron=degraded, queue=unavailable, failures_last_60m=3, pending_older_15m=12, activity_last_60m=n/a"`
+- `ProbeDetail[cron_queue_health_snapshot] subsystem=cron item=failures_last_60m status=warn value="3"`
+- `ProbeDetail[cron_queue_health_snapshot] subsystem=queue item=tables_present status=unavailable value="false"`
+
+## Probe Status Matrix (v1)
+
+| Probe | Condition | Status |
+|------|-----------|--------|
+| Indexer | any indexer invalid/reindex-required | `warn` |
+| Indexer | no invalid/reindex-required indexers and all modes readable | `ok` |
+| Indexer | no invalid indexers but one or more mode values unavailable | `unknown` |
+| Cache | cache types readable + backend adapter resolves | `ok` |
+| Cache | cache types readable + backend adapter resolution fails | `warn` |
+| Cache | cache metadata read fails | `unknown` |
+| Cache | default frontend cannot be resolved | `unknown` |
+| Cron | failures in lookback OR pending backlog threshold exceeded | `warn` |
+| Cron | warning thresholds not hit | `ok` |
+| Cron | cron data source unavailable | `unknown` |
+| Queue | required queue tables absent | `unavailable` |
+| Queue | tables present + queryable + no warning condition | `ok` |
+| Queue | tables present + no activity in lookback while cron is warn | `warn` |
+| Queue | tables present but query fails | `unknown` |
+
 ### Regression gate
 - run full suite: `vendor/bin/phpunit`
+
+### Manual validation checklist (required)
+- CLI kick path:
+  - run `bin/magento chaosdonkey:kick` with probe roll outcomes forced/mocked
+  - verify canonical `Probe[...]` and `ProbeDetail[...]` lines
+- Status command regression:
+  - run `bin/magento chaosdonkey:status`
+  - verify output remains unchanged
+- Admin config-path verification:
+  - verify new toggles persist/read under `admin/chaos_donkey/*`
+- Cron path:
+  - run cron-triggered kick and verify probe-prefixed log lines
+  - verify no probe logs when probe toggles are disabled
 
 ## Out of Scope
 - separate dedicated probe CLI command
@@ -163,8 +459,10 @@ Coverage focus:
 3. Probe outcomes can execute via both CLI and cron kick paths.
 4. Disabled probes follow existing reroll/fallback semantics.
 5. Probe output provides concise summary + top details.
-6. Existing action behavior is preserved.
-7. Relevant unit tests pass, and full suite remains green.
+6. Fixed roll mapping (`5/6/7`) is covered by resolver tests.
+7. Cron-triggered probe runs produce visibility logs with bounded details.
+8. Existing action behavior is preserved.
+9. Relevant unit tests pass, and full suite remains green.
 
 ## Recommendation
 Implement Phase 3 using the probe abstraction layer with first-class action integration. This preserves current architecture, follows Magento DI/config patterns, improves operator visibility, and keeps future probe expansion maintainable.

--- a/docs/superpowers/specs/2026-03-29-chaos-actions-phase-3-read-only-probes-design.md
+++ b/docs/superpowers/specs/2026-03-29-chaos-actions-phase-3-read-only-probes-design.md
@@ -1,0 +1,170 @@
+# ChaosDonkey Phase 3 Design: Read-Only Probe Actions
+
+Date: 2026-03-29
+Scope: Add Magento-aligned read-only probe actions to the existing kick flow
+
+## Status
+- Design approved in brainstorming session (implementation not started)
+
+## Goal
+Expand ChaosDonkey with read-only operational probes that improve operator visibility while preserving the existing `chaosdonkey:kick` orchestration model and Magento best practices.
+
+## Confirmed Product Decisions
+- Phase focus: action expansion (Phase 3)
+- Action family: read-only stress probes
+- Initial scope: 3 probes
+- Primary success criterion: operator visibility
+- Trigger model: via existing kick rolls (not a separate probe command)
+- Probe types:
+  - indexer status snapshot
+  - cache backend health snapshot
+  - queue/cron health snapshot
+- Cron behavior: probes are eligible in both cron and CLI kick execution
+- Roll mapping strategy: replace existing non-action (`napping`) slots with probe outcomes
+- Output depth: summary + top details
+- Config controls: per-probe admin enable toggles
+- Architectural direction: probe abstraction layer (Magento best-practice oriented)
+
+## Architecture
+Phase 3 extends the current action framework by introducing a small probe abstraction while keeping probes as first-class kick outcomes.
+
+Core principles:
+- Keep command entrypoints thin and orchestration centralized in `Model/KickExecutor`.
+- Keep probe behaviors isolated in single-purpose action classes.
+- Preserve the existing DI action pool pattern and config-driven gating.
+- Reuse existing reroll/fallback semantics for disabled actions.
+
+Planned shape:
+- Existing `ChaosActionInterface` remains the execution contract used by the action pool.
+- Add `Api/ProbeActionInterface` as a probe-specific marker/contract for read-only action semantics and future extensibility.
+- Probe actions implement both interfaces.
+- Add shared probe output formatting service for consistent “summary + top details” output.
+
+This balances immediate delivery with maintainability if probe count grows in later phases.
+
+## Components and Responsibilities
+
+### New interfaces/services
+- `Api/ProbeActionInterface.php`
+  - Defines probe-specific contract/semantics for read-only probes.
+  - Keeps probe concerns explicit without changing existing action pool behavior.
+
+- `Model/Probe/ProbeOutputFormatter.php`
+  - Shared formatter for concise operator output.
+  - Produces a stable shape:
+    - summary headline
+    - bounded top details (warnings, notable counters/items)
+
+### New actions
+- `Action/IndexerStatusSnapshot.php`
+  - Read-only snapshot of indexer mode/state indicators.
+
+- `Action/CacheBackendHealthSnapshot.php`
+  - Read-only snapshot of cache type/backend health signals.
+
+- `Action/CronQueueHealthSnapshot.php`
+  - Read-only snapshot for cron/queue health indicators available within module constraints.
+
+### Existing components to extend
+- `etc/di.xml`
+  - Register new probe action codes in the action pool map.
+
+- `Model/RollOutcomeResolver.php`
+  - Add probe outcomes by replacing selected `napping` roll slots.
+
+- `Model/KickExecutor.php`
+  - Include probe codes in reroll-eligible action code set.
+  - Preserve existing retry limit and fallback behavior.
+
+- `etc/adminhtml/system.xml`
+  - Add per-probe yes/no toggles under `admin/chaos_donkey`.
+
+- `etc/config.xml`
+  - Add defaults for per-probe toggles.
+
+- `Model/Config.php`
+  - Add config path constants + typed accessors.
+  - Extend `isActionEnabled()` action-code gating to probe codes.
+
+## Config Model and Naming
+Use stable, feature-oriented config paths under existing namespace:
+
+- `admin/chaos_donkey/enable_indexer_status_snapshot`
+- `admin/chaos_donkey/enable_cache_backend_health_snapshot`
+- `admin/chaos_donkey/enable_cron_queue_health_snapshot`
+
+Config UX policy:
+- `system.xml` yes/no select fields (`Magento\Config\Model\Config\Source\Yesno`)
+- explicit operational comments for each toggle
+- defaults defined in `etc/config.xml`
+- maintain current scope policy used by module’s operational settings
+
+## Runtime Data Flow
+1. Kick starts via CLI command or cron-triggered job.
+2. `KickExecutor` rolls D20.
+3. `RollOutcomeResolver` maps roll to outcome code.
+4. If outcome is action/probe and toggle is disabled:
+   - reroll up to current cap (20 attempts).
+5. If attempts exhausted:
+   - fallback to `napping` (unchanged).
+6. If enabled action/probe selected:
+   - `ActionPool` resolves action service by outcome code.
+   - action executes and emits summary + top details.
+7. Existing state persistence (`last_run`, `last_kick`, `last_outcome`) remains unchanged.
+
+## Error Handling and Safety
+- Probe actions are read-only by contract.
+- Probe failures should degrade gracefully where possible:
+  - provide clear warning lines to operator output
+  - avoid crashing entire kick flow for recoverable probe-source issues
+- Keep detail output bounded to avoid log/console noise.
+- Use PSR-3 logging only for diagnostics that complement console output.
+- Do not leak sensitive backend details in probe output.
+
+## Testing Strategy
+
+### Unit tests to add
+- `Test/Unit/Action/IndexerStatusSnapshotTest.php`
+- `Test/Unit/Action/CacheBackendHealthSnapshotTest.php`
+- `Test/Unit/Action/CronQueueHealthSnapshotTest.php`
+
+Coverage focus:
+- summary output correctness
+- top-detail inclusion/capping
+- graceful handling for unavailable/partial data
+
+### Unit tests to update
+- `Test/Unit/Model/ConfigTest.php`
+  - new toggle accessors/constants and action-code enable checks
+
+- `Test/Unit/Model/RollOutcomeResolverTest.php`
+  - new probe roll mappings
+
+- `Test/Unit/Model/KickExecutorTest.php`
+  - reroll behavior for disabled probes
+  - fallback behavior when probe/action outcomes are unavailable
+
+- `Test/Unit/Console/Command/ChaosDonkeyKickTest.php` (as needed)
+  - probe output surfaced through existing command pipeline
+
+### Regression gate
+- run full suite: `vendor/bin/phpunit`
+
+## Out of Scope
+- separate dedicated probe CLI command
+- probe scheduling independent from current kick/cron flow
+- probe history persistence tables or dashboards
+- configurable roll mapping UI
+- non-read-only state-changing probe behaviors
+
+## Acceptance Criteria
+1. Three read-only probes are available as kick outcomes.
+2. Each probe has an admin toggle and default config value.
+3. Probe outcomes can execute via both CLI and cron kick paths.
+4. Disabled probes follow existing reroll/fallback semantics.
+5. Probe output provides concise summary + top details.
+6. Existing action behavior is preserved.
+7. Relevant unit tests pass, and full suite remains green.
+
+## Recommendation
+Implement Phase 3 using the probe abstraction layer with first-class action integration. This preserves current architecture, follows Magento DI/config patterns, improves operator visibility, and keeps future probe expansion maintainable.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -21,6 +21,21 @@
                     <label>Enable GraphQL Pipeline Stress</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="enable_indexer_status_snapshot" translate="label" type="select" sortOrder="45" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Indexer Status Snapshot</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>When enabled, the command can trigger an indexer status snapshot probe.</comment>
+                </field>
+                <field id="enable_cache_backend_health_snapshot" translate="label" type="select" sortOrder="46" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Cache Backend Health Snapshot</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>When enabled, the command can trigger a cache backend health probe.</comment>
+                </field>
+                <field id="enable_cron_queue_health_snapshot" translate="label" type="select" sortOrder="47" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enable Cron/Queue Health Snapshot</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>When enabled, the command can trigger a cron and queue health probe.</comment>
+                </field>
                 <field id="cron_enabled" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Cron Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,9 @@
                 <enable_reindex_all>1</enable_reindex_all>
                 <enable_cache_flush>1</enable_cache_flush>
                 <enable_graphql_pipeline_stress>1</enable_graphql_pipeline_stress>
+                <enable_indexer_status_snapshot>1</enable_indexer_status_snapshot>
+                <enable_cache_backend_health_snapshot>1</enable_cache_backend_health_snapshot>
+                <enable_cron_queue_health_snapshot>1</enable_cron_queue_health_snapshot>
                 <cron_enabled>0</cron_enabled>
                 <cron_expression>*/30 * * * *</cron_expression>
                 <cron_allowed_hours></cron_allowed_hours>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="ShaunMcManus\ChaosDonkey\Model\ActionPool">
-        <arguments>
-            <argument name="actions" xsi:type="array">
-                <item name="reindex_all" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\ReindexAll</item>
-                <item name="cache_flush" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\CacheFlush</item>
-                <item name="graphql_pipeline_stress" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\GraphQlInternalPipelineStress</item>
-            </argument>
-        </arguments>
-    </type>
+            <arguments>
+                <argument name="actions" xsi:type="array">
+                    <item name="reindex_all" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\ReindexAll</item>
+                    <item name="cache_flush" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\CacheFlush</item>
+                    <item name="graphql_pipeline_stress" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\GraphQlInternalPipelineStress</item>
+                    <item name="indexer_status_snapshot" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\IndexerStatusSnapshot</item>
+                    <item name="cache_backend_health_snapshot" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\CacheBackendHealthSnapshot</item>
+                    <item name="cron_queue_health_snapshot" xsi:type="object">ShaunMcManus\ChaosDonkey\Action\CronQueueHealthSnapshot</item>
+                </argument>
+            </arguments>
+        </type>
 
     <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,4 +18,9 @@
             </argument>
         </arguments>
     </type>
+
+    <preference
+        for="ShaunMcManus\ChaosDonkey\Model\Probe\ClockInterface"
+        type="ShaunMcManus\ChaosDonkey\Model\Probe\SystemClock"
+    />
 </config>


### PR DESCRIPTION
## Summary
- expand `chaosdonkey:status` with a `Configured Action/Probe Toggles` section showing each configurable action/probe outcome as enabled or disabled
- keep the existing top status section unchanged while reusing `Config::isActionEnabled()` for the new toggle summary
- document the expanded status output and its store/default scope semantics in the README

## Test Plan
- [x] `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyStatusTest.php`
- [x] `vendor/bin/phpunit`