### PR TITLE
Add execution history visibility and graceful degradation

### DIFF
--- a/Console/Command/ChaosDonkeyKick.php
+++ b/Console/Command/ChaosDonkeyKick.php
@@ -45,7 +45,7 @@ class ChaosDonkeyKick extends Command
             return Command::SUCCESS;
         }
 
-        $result = $this->kickExecutor->execute();
+        $result = $this->kickExecutor->execute('cli');
 
         foreach ($result['messages'] as $message) {
             $output->writeln($message);

--- a/Console/Command/ChaosDonkeyStatus.php
+++ b/Console/Command/ChaosDonkeyStatus.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace ShaunMcManus\ChaosDonkey\Console\Command;
 
 use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\ExecutionHistoryStorage;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,12 +20,17 @@ class ChaosDonkeyStatus extends Command
         'cron_queue_health_snapshot' => 'Cron queue health snapshot',
     ];
 
+    private const RECENT_HISTORY_LIMIT = 5;
+
     private Config $config;
 
-    public function __construct(Config $config)
+    private ExecutionHistoryStorage $executionHistoryStorage;
+
+    public function __construct(Config $config, ExecutionHistoryStorage $executionHistoryStorage)
     {
         parent::__construct();
         $this->config = $config;
+        $this->executionHistoryStorage = $executionHistoryStorage;
     }
 
     /**
@@ -50,6 +56,14 @@ class ChaosDonkeyStatus extends Command
         $configuredProfile = $this->config->getExecutionProfile();
         $effectiveProfile = $this->config->getEffectiveExecutionProfile();
         $fallbackReason = $this->config->getExecutionProfileFallbackReason();
+        $recentHistoryUnavailable = false;
+
+        try {
+            $recentHistory = $this->executionHistoryStorage->getRecent(self::RECENT_HISTORY_LIMIT);
+        } catch (\Throwable) {
+            $recentHistoryUnavailable = true;
+            $recentHistory = [];
+        }
 
         $output->writeln('ChaosDonkey Status');
         $output->writeln('Enabled: ' . $enabled);
@@ -68,6 +82,19 @@ class ChaosDonkeyStatus extends Command
         }
 
         $output->writeln('');
+        $output->writeln('Recent execution history');
+
+        if ($recentHistoryUnavailable) {
+            $output->writeln('History unavailable.');
+        } elseif ($recentHistory === []) {
+            $output->writeln('None recorded.');
+        } else {
+            foreach ($recentHistory as $historyRow) {
+                $output->writeln($this->formatRecentHistoryRow($historyRow));
+            }
+        }
+
+        $output->writeln('');
         $output->writeln('Configured Action/Probe Toggles');
 
         foreach (self::ACTION_LABELS as $actionCode => $label) {
@@ -75,5 +102,29 @@ class ChaosDonkeyStatus extends Command
         }
 
         return Command::SUCCESS;
+    }
+
+    private function formatRecentHistoryRow(array $historyRow): string
+    {
+        $profileSummary = (string) $historyRow['configured_profile'];
+
+        if ((string) $historyRow['configured_profile'] !== (string) $historyRow['effective_profile']) {
+            $profileSummary .= ' -> ' . (string) $historyRow['effective_profile'];
+        }
+
+        $line = sprintf(
+            '- %s | %s | kick %s | %s | profile %s',
+            (string) $historyRow['executed_at'],
+            (string) $historyRow['source'],
+            (string) $historyRow['kick'],
+            (string) $historyRow['outcome'],
+            $profileSummary
+        );
+
+        if ($historyRow['fallback_reason'] !== null && $historyRow['fallback_reason'] !== '') {
+            $line .= ' | fallback ' . (string) $historyRow['fallback_reason'];
+        }
+
+        return $line;
     }
 }

--- a/Cron/ChaosDonkeyKickCron.php
+++ b/Cron/ChaosDonkeyKickCron.php
@@ -60,7 +60,7 @@ class ChaosDonkeyKickCron
 
         $this->logMessage(sprintf('Executing ChaosDonkey cron at hour %d.', $currentHour));
 
-        $result = $this->kickExecutor->execute();
+        $result = $this->kickExecutor->execute('cron');
 
         foreach ($result['messages'] as $message) {
             if (str_starts_with($message, 'Probe[') || str_starts_with($message, 'ProbeDetail[')) {

--- a/Model/ExecutionHistoryStorage.php
+++ b/Model/ExecutionHistoryStorage.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Model;
+
+use Magento\Framework\App\ResourceConnection;
+
+class ExecutionHistoryStorage
+{
+    private const TABLE_NAME = 'shaunmcmanus_chaosdonkey_execution_history';
+
+    private const SELECT_COLUMNS = 'history_id, executed_at, source, kick, outcome, configured_profile, effective_profile, fallback_reason';
+
+    public function __construct(private readonly ResourceConnection $resourceConnection)
+    {
+    }
+
+    public function append(
+        string $executedAt,
+        string $source,
+        int $kick,
+        string $outcome,
+        string $configuredProfile,
+        string $effectiveProfile,
+        ?string $fallbackReason
+    ): void {
+        $this->resourceConnection
+            ->getConnection()
+            ->insert($this->resourceConnection->getTableName(self::TABLE_NAME), [
+                'executed_at' => $executedAt,
+                'source' => $source,
+                'kick' => $kick,
+                'outcome' => $outcome,
+                'configured_profile' => $configuredProfile,
+                'effective_profile' => $effectiveProfile,
+                'fallback_reason' => $fallbackReason,
+            ]);
+    }
+
+    public function getRecent(int $limit): array
+    {
+        if ($limit < 1) {
+            return [];
+        }
+
+        $tableName = $this->resourceConnection->getTableName(self::TABLE_NAME);
+        $sql = sprintf(
+            'SELECT %s FROM %s ORDER BY history_id DESC LIMIT %d',
+            self::SELECT_COLUMNS,
+            $tableName,
+            $limit
+        );
+
+        return $this->resourceConnection->getConnection()->fetchAll($sql);
+    }
+}

--- a/Model/KickExecutor.php
+++ b/Model/KickExecutor.php
@@ -37,7 +37,8 @@ class KickExecutor
         private ActionPool $actionPool,
         private ProfiledRollSelector $profiledRollSelector,
         private StateWriter $stateWriter,
-        private KickRoller $kickRoller
+        private KickRoller $kickRoller,
+        private ExecutionHistoryStorage $executionHistoryStorage
     ) {
     }
 
@@ -48,7 +49,7 @@ class KickExecutor
      *     messages: list<string>
      * }
      */
-    public function execute(): array
+    public function execute(string $source): array
     {
         $messages = [];
         $enabledActions = $this->getEnabledActions();
@@ -94,9 +95,23 @@ class KickExecutor
             };
         }
 
-        $this->stateWriter->saveLastRun((new \DateTimeImmutable())->format(DATE_ATOM));
+        $executedAt = new \DateTimeImmutable();
+
+        $this->stateWriter->saveLastRun($executedAt->format(DATE_ATOM));
         $this->stateWriter->saveLastKick($kick);
         $this->stateWriter->saveLastOutcome($outcome);
+        try {
+            $this->executionHistoryStorage->append(
+                $executedAt->format('Y-m-d H:i:s'),
+                $source,
+                $kick,
+                $outcome,
+                $selection['configured_profile'],
+                $selection['effective_profile'],
+                $selection['fallback_reason']
+            );
+        } catch (\Throwable) {
+        }
 
         return [
             'kick' => $kick,

--- a/Plans.md
+++ b/Plans.md
@@ -1,10 +1,27 @@
-# Plans
+# ChaosDonkey Plans.md
 
-## Active
-- None yet.
+作成日: 2026-04-02
 
-## Backlog
-- None yet.
+---
 
-## Done
-- None yet.
+## Phase 5: Execution history and operator visibility
+
+Purpose: Persist recent executed kicks from the shared execution path and surface a compact operator-facing history view.
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| 5.1 | Add persistent execution history storage for recent runs | A module-owned persistence shape exists for execution history and automated tests prove the expected schema/config contract | - | cc:完了 |
+| 5.2 | Record executed CLI and cron runs through the shared execution path | Automated tests prove both CLI and cron executions append a history record with source, kick, outcome, and profile context | 5.1 | cc:完了 |
+| 5.3 | Extend `chaosdonkey:status` with a compact recent-history section | Command output includes a bounded recent-history summary without regressing existing status lines, proven by command tests | 5.2 | cc:完了 |
+| 5.4 | Document history behavior and operator expectations | `README.md` documents what is recorded, what is intentionally excluded, and how operators read the new status output | 5.3 | cc:完了 |
+| 5.5 | Run full verification and close the phase | `vendor/bin/phpunit` passes and the working tree is ready for branch-finishing workflow | 5.4 | cc:完了 |
+
+## Phase 6: Execution history hardening
+
+Purpose: Make execution history best-effort operator visibility instead of a hard runtime dependency for kick, cron, and status paths.
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| 6.1 | Degrade gracefully when execution-history writes fail | CLI and cron executions still complete and keep `last_*` state updates when history insertion fails or the table is unavailable, proven by targeted automated tests | Phase 5 | cc:完了 |
+| 6.2 | Degrade gracefully when status history reads fail | `chaosdonkey:status` still renders the core operator snapshot and a safe history placeholder when history queries fail, proven by command tests | 6.1 | cc:完了 |
+| 6.3 | Re-document degraded-history behavior and re-verify the branch | `README.md` documents degraded history behavior and `composer validate --no-check-publish` plus `vendor/bin/phpunit` pass after the hardening changes | 6.2 | cc:完了 |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Rolls a D20 and executes an outcome selected from the active execution profile.
   - `admin/chaos_donkey/last_run` (ISO-8601 timestamp)
   - `admin/chaos_donkey/last_kick` (rolled value)
   - `admin/chaos_donkey/last_outcome` (outcome key)
+- Each executed run also appends a recent-history row to the module-owned `shaunmcmanus_chaosdonkey_execution_history` table.
+- Execution-history persistence is best-effort operator visibility, not a hard runtime dependency. If the history insert fails or the table is temporarily unavailable, `chaosdonkey:kick` still completes and still updates `last_run`, `last_kick`, and `last_outcome`; only the history row is skipped.
+- Recorded history fields are:
+  - `executed_at` (database `datetime` timestamp)
+  - `source` (`cli` for `chaosdonkey:kick`, `cron` for scheduled execution)
+  - `kick` (rolled value)
+  - `outcome` (selected outcome key)
+  - `configured_profile` (configured profile at execution time)
+  - `effective_profile` (runtime profile after fallback handling)
+  - `fallback_reason` (only when a fallback was needed)
+- Execution history intentionally does **not** persist the executor message payload, probe detail rows, or toggle snapshots. Those remain in command output and cron logs only.
 
 Execution profile setting:
 - Config path: `admin/chaos_donkey/execution_profile`
@@ -90,6 +101,10 @@ Cron execution skips when:
 
 When it does run, cron delegates to the same kick execution pipeline as `chaosdonkey:kick`, so execution profile selection, action/probe eligibility gating, and state persistence behave the same way.
 
+Because cron uses the same shared execution path, successful cron runs also append execution-history rows with `source=cron`.
+
+If cron history persistence fails or the history table is temporarily unavailable, cron still completes the kick path and still updates the shared `last_*` state snapshot; only the history row is skipped.
+
 Cron log behavior:
 - Always logs startup, skip reasons, and completion.
 - Logs only probe/probe-detail lines from command output (`Probe[...]`, `ProbeDetail[...]`) and preserves them unchanged.
@@ -105,6 +120,9 @@ Shows the operator-oriented status snapshot for ChaosDonkey.
 - Configured profile — reads `admin/chaos_donkey/execution_profile` from default scope.
 - Effective profile — resolved profile used at runtime after fallback handling.
 - Fallback reason (only when present) — indicates why configured and effective profiles differ.
+- Recent execution history — shows up to 5 most recent recorded executions. Each line includes the execution timestamp, source (`cli` or `cron`), rolled kick, selected outcome, and profile summary. When configured and effective profiles differ, the line shows `configured -> effective`; when a fallback reason exists, it is appended to that line.
+- Empty history behavior — prints `None recorded.` until the first successful CLI or cron execution is stored and readable.
+- Degraded history-read behavior — if recent-history lookup fails, `chaosdonkey:status` still renders the core operator snapshot and toggle section, and the recent-history block prints `History unavailable.` instead of aborting the command.
 - Configured Action/Probe Toggles (default scope):
   - `Reindex all: Enabled|Disabled`
   - `Cache flush: Enabled|Disabled`
@@ -113,7 +131,7 @@ Shows the operator-oriented status snapshot for ChaosDonkey.
   - `Cache backend health snapshot: Enabled|Disabled`
   - `Cron queue health snapshot: Enabled|Disabled`
 
-This makes the runtime values (last run/kick/outcome) and toggle rows explicit as `default` scope configuration, while module enabled state follows the existing store-scoped status command behavior.
+This makes the runtime values (last run/kick/outcome), bounded recent execution history, and toggle rows explicit as `default` scope configuration, while module enabled state follows the existing store-scoped status command behavior.
 
 ## Reindex Behavior
 

--- a/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -10,5 +10,12 @@ interface AdapterInterface
     /**
      * @param array<string, mixed> $bind
      */
+    public function insert(string $tableName, array $bind): void;
+
+    /**
+     * @param array<string, mixed> $bind
+     */
     public function fetchOne(string $sql, array $bind = []): mixed;
+
+    public function fetchAll(string $sql, array $bind = []): array;
 }

--- a/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyKickTest.php
@@ -41,6 +41,7 @@ class ChaosDonkeyKickTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cli')
             ->willReturn([
                 'kick' => 3,
                 'outcome' => 'cache_flush',
@@ -72,6 +73,7 @@ class ChaosDonkeyKickTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cli')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'indexer_status_snapshot',
@@ -106,6 +108,7 @@ class ChaosDonkeyKickTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cli')
             ->willReturn([
                 'kick' => 11,
                 'outcome' => 'napping',

--- a/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
@@ -5,21 +5,26 @@ namespace ShaunMcManus\ChaosDonkey\Test\Unit\Console\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use ShaunMcManus\ChaosDonkey\Console\Command\ChaosDonkeyStatus;
 use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\ExecutionHistoryStorage;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ChaosDonkeyStatusTest extends TestCase
 {
     private Config&MockObject $config;
 
+    private ExecutionHistoryStorage&MockObject $executionHistoryStorage;
+
     protected function setUp(): void
     {
-        $this->config = $this->createMock(Config::class);
+        $this->executionHistoryStorage = $this->createMock(ExecutionHistoryStorage::class);
     }
 
     public function testItDisplaysCurrentStatusValues(): void
     {
+        $this->config = $this->createMock(Config::class);
         $this->config
             ->expects(self::once())
             ->method('isEnabled')
@@ -48,9 +53,9 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->expectRecentHistory([]);
 
-        $command = new ChaosDonkeyStatus($this->config);
-        $tester = new CommandTester($command);
+        $tester = $this->createCommandTester();
 
         $exitCode = $tester->execute([]);
         $display = $tester->getDisplay();
@@ -63,10 +68,13 @@ class ChaosDonkeyStatusTest extends TestCase
         self::assertStringContainsString('Last outcome: reindex_all', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Recent execution history', $display);
+        self::assertStringContainsString('None recorded.', $display);
     }
 
     public function testItDisplaysUnknownWhenNoSavedStateExists(): void
     {
+        $this->config = $this->createMock(Config::class);
         $this->config
             ->expects(self::once())
             ->method('isEnabled')
@@ -95,9 +103,9 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->expectRecentHistory([]);
 
-        $command = new ChaosDonkeyStatus($this->config);
-        $tester = new CommandTester($command);
+        $tester = $this->createCommandTester();
 
         $exitCode = $tester->execute([]);
 
@@ -110,11 +118,14 @@ class ChaosDonkeyStatusTest extends TestCase
         self::assertStringContainsString('Last outcome: Never', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Recent execution history', $display);
+        self::assertStringContainsString('None recorded.', $display);
 
     }
 
     public function testItDisplaysCurrentStatusWithActionAndProbeToggles(): void
     {
+        $this->config = $this->createMock(Config::class);
         $actionStates = [
             'reindex_all' => true,
             'cache_flush' => false,
@@ -154,6 +165,7 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->expectRecentHistory([]);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
@@ -163,8 +175,7 @@ class ChaosDonkeyStatusTest extends TestCase
                 return $actionStates[$code];
             });
 
-        $command = new ChaosDonkeyStatus($this->config);
-        $tester = new CommandTester($command);
+        $tester = $this->createCommandTester();
 
         $exitCode = $tester->execute([]);
         $display = trim($tester->getDisplay());
@@ -177,6 +188,9 @@ Last kick: 2
 Last outcome: reindex_all
 Configured profile: balanced
 Effective profile: balanced
+
+Recent execution history
+None recorded.
 
 Configured Action/Probe Toggles
 Reindex all: Enabled
@@ -207,6 +221,7 @@ OUTPUT;
 
     public function testItDisplaysDisabledModuleAndMixedToggles(): void
     {
+        $this->config = $this->createMock(Config::class);
         $actionStates = [
             'reindex_all' => false,
             'cache_flush' => false,
@@ -246,6 +261,7 @@ OUTPUT;
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->expectRecentHistory([]);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
@@ -255,8 +271,7 @@ OUTPUT;
                 return $actionStates[$code];
             });
 
-        $command = new ChaosDonkeyStatus($this->config);
-        $tester = new CommandTester($command);
+        $tester = $this->createCommandTester();
 
         $tester->execute([]);
 
@@ -268,6 +283,8 @@ OUTPUT;
         self::assertStringContainsString('Last outcome: Never', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Recent execution history', $display);
+        self::assertStringContainsString('None recorded.', $display);
         self::assertStringContainsString('Configured Action/Probe Toggles', $display);
         self::assertStringContainsString('Reindex all: Disabled', $display);
         self::assertStringContainsString('GraphQL pipeline stress: Enabled', $display);
@@ -288,8 +305,106 @@ OUTPUT;
         self::assertStringNotContainsString('napping', $display);
     }
 
+    public function testItDisplaysSafeHistoryPlaceholderWhenRecentHistoryReadFails(): void
+    {
+        $this->config = $this->createMock(Config::class);
+        $actionStates = [
+            'reindex_all' => true,
+            'cache_flush' => false,
+            'graphql_pipeline_stress' => true,
+            'indexer_status_snapshot' => true,
+            'cache_backend_health_snapshot' => false,
+            'cron_queue_health_snapshot' => true,
+        ];
+
+        $requestedActionCodes = [];
+
+        $this->config
+            ->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastRun')
+            ->willReturn('2026-03-28T20:22:00+00:00');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastKick')
+            ->willReturn('2');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastOutcome')
+            ->willReturn('reindex_all');
+        $this->config
+            ->expects(self::once())
+            ->method('getExecutionProfile')
+            ->willReturn('balanced');
+        $this->config
+            ->expects(self::once())
+            ->method('getEffectiveExecutionProfile')
+            ->willReturn('balanced');
+        $this->config
+            ->expects(self::once())
+            ->method('getExecutionProfileFallbackReason')
+            ->willReturn(null);
+        $this->executionHistoryStorage
+            ->expects(self::once())
+            ->method('getRecent')
+            ->with(5)
+            ->willThrowException(new RuntimeException('history query failed'));
+        $this->config
+            ->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnCallback(function (string $code) use (&$requestedActionCodes, $actionStates): bool {
+                $requestedActionCodes[] = $code;
+
+                return $actionStates[$code];
+            });
+
+        $tester = $this->createCommandTester();
+
+        $exitCode = $tester->execute([]);
+        $display = trim($tester->getDisplay());
+
+        $expectedOutput = <<<OUTPUT
+ChaosDonkey Status
+Enabled: Yes
+Last run: 2026-03-28T20:22:00+00:00
+Last kick: 2
+Last outcome: reindex_all
+Configured profile: balanced
+Effective profile: balanced
+
+Recent execution history
+History unavailable.
+
+Configured Action/Probe Toggles
+Reindex all: Enabled
+Cache flush: Disabled
+GraphQL pipeline stress: Enabled
+Indexer status snapshot: Enabled
+Cache backend health snapshot: Disabled
+Cron queue health snapshot: Enabled
+OUTPUT;
+
+        self::assertSame(0, $exitCode);
+        self::assertSame($expectedOutput, $display);
+        self::assertSame(
+            [
+                'reindex_all',
+                'cache_flush',
+                'graphql_pipeline_stress',
+                'indexer_status_snapshot',
+                'cache_backend_health_snapshot',
+                'cron_queue_health_snapshot',
+            ],
+            $requestedActionCodes
+        );
+    }
+
     public function testItShowsAllDisabledTogglesAsDisabled(): void
     {
+        $this->config = $this->createMock(Config::class);
         $this->config
             ->expects(self::once())
             ->method('isEnabled')
@@ -318,13 +433,13 @@ OUTPUT;
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->expectRecentHistory([]);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturn(false);
 
-        $command = new ChaosDonkeyStatus($this->config);
-        $tester = new CommandTester($command);
+        $tester = $this->createCommandTester();
 
         $tester->execute([]);
 
@@ -350,9 +465,28 @@ OUTPUT;
             effectiveProfile: 'balanced',
             fallbackReason: 'invalid_profile_table'
         );
+        $this->expectRecentHistory([
+            [
+                'executed_at' => '2026-04-02 10:15:00',
+                'source' => 'cron',
+                'kick' => '7',
+                'outcome' => 'napping',
+                'configured_profile' => 'balanced',
+                'effective_profile' => 'balanced',
+                'fallback_reason' => null,
+            ],
+            [
+                'executed_at' => '2026-04-02 09:45:00',
+                'source' => 'cli',
+                'kick' => '3',
+                'outcome' => 'cache_flush',
+                'configured_profile' => 'chaos',
+                'effective_profile' => 'balanced',
+                'fallback_reason' => 'invalid_profile_table',
+            ],
+        ]);
 
-        $command = new ChaosDonkeyStatus($config);
-        $tester = new CommandTester($command);
+        $tester = new CommandTester(new ChaosDonkeyStatus($config, $this->executionHistoryStorage));
 
         $tester->execute([]);
 
@@ -361,6 +495,9 @@ OUTPUT;
         self::assertStringContainsString('Configured profile: chaos', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
         self::assertStringContainsString('Fallback reason: invalid_profile_table', $display);
+        self::assertStringContainsString('Recent execution history', $display);
+        self::assertStringContainsString('- 2026-04-02 10:15:00 | cron | kick 7 | napping | profile balanced', $display);
+        self::assertStringContainsString('- 2026-04-02 09:45:00 | cli | kick 3 | cache_flush | profile chaos -> balanced | fallback invalid_profile_table', $display);
     }
 
     public function testItDisplaysEmergencyFallbackContractForCorruptBalancedProfile(): void
@@ -370,9 +507,9 @@ OUTPUT;
             effectiveProfile: 'balanced',
             fallbackReason: 'invalid_fallback_profile'
         );
+        $this->expectRecentHistory([]);
 
-        $command = new ChaosDonkeyStatus($config);
-        $tester = new CommandTester($command);
+        $tester = new CommandTester(new ChaosDonkeyStatus($config, $this->executionHistoryStorage));
 
         $tester->execute([]);
 
@@ -382,6 +519,22 @@ OUTPUT;
         self::assertStringContainsString('Effective profile: balanced', $display);
         self::assertStringContainsString('Fallback reason: invalid_fallback_profile', $display);
         self::assertStringContainsString('Fallback mode: emergency_legacy_balanced_table', $display);
+        self::assertStringContainsString('Recent execution history', $display);
+        self::assertStringContainsString('None recorded.', $display);
+    }
+
+    private function expectRecentHistory(array $historyRows): void
+    {
+        $this->executionHistoryStorage
+            ->expects(self::once())
+            ->method('getRecent')
+            ->with(5)
+            ->willReturn($historyRows);
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        return new CommandTester(new ChaosDonkeyStatus($this->config, $this->executionHistoryStorage));
     }
 
     private function createProfileStatusConfigDouble(

--- a/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
+++ b/Test/Unit/Cron/ChaosDonkeyKickCronTest.php
@@ -88,6 +88,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'napping',
@@ -115,6 +116,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'napping',
@@ -149,6 +151,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'napping',
@@ -179,6 +182,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'napping',
@@ -216,6 +220,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 5,
                 'outcome' => 'napping',
@@ -292,6 +297,7 @@ class ChaosDonkeyKickCronTest extends TestCase
         $this->kickExecutor
             ->expects(self::once())
             ->method('execute')
+            ->with('cron')
             ->willReturn([
                 'kick' => 11,
                 'outcome' => 'napping',

--- a/Test/Unit/Etc/DbSchemaXmlTest.php
+++ b/Test/Unit/Etc/DbSchemaXmlTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Etc;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\TestCase;
+
+class DbSchemaXmlTest extends TestCase
+{
+    public function testItDeclaresExecutionHistoryTableWithExpectedColumns(): void
+    {
+        $xpath = $this->createXPath();
+
+        $historyId = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='history_id']"
+        );
+        self::assertSame('int', $historyId->getAttribute('xsi:type'));
+        self::assertSame('true', $historyId->getAttribute('unsigned'));
+        self::assertSame('true', $historyId->getAttribute('identity'));
+        self::assertSame('false', $historyId->getAttribute('nullable'));
+
+        $executedAt = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='executed_at']"
+        );
+        self::assertSame('datetime', $executedAt->getAttribute('xsi:type'));
+        self::assertSame('false', $executedAt->getAttribute('nullable'));
+
+        $source = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='source']"
+        );
+        self::assertSame('varchar', $source->getAttribute('xsi:type'));
+        self::assertSame('16', $source->getAttribute('length'));
+        self::assertSame('false', $source->getAttribute('nullable'));
+
+        $kick = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='kick']"
+        );
+        self::assertSame('int', $kick->getAttribute('xsi:type'));
+        self::assertSame('true', $kick->getAttribute('unsigned'));
+        self::assertSame('false', $kick->getAttribute('nullable'));
+
+        $outcome = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='outcome']"
+        );
+        self::assertSame('varchar', $outcome->getAttribute('xsi:type'));
+        self::assertSame('64', $outcome->getAttribute('length'));
+        self::assertSame('false', $outcome->getAttribute('nullable'));
+
+        $configuredProfile = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='configured_profile']"
+        );
+        self::assertSame('varchar', $configuredProfile->getAttribute('xsi:type'));
+        self::assertSame('32', $configuredProfile->getAttribute('length'));
+        self::assertSame('false', $configuredProfile->getAttribute('nullable'));
+
+        $effectiveProfile = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='effective_profile']"
+        );
+        self::assertSame('varchar', $effectiveProfile->getAttribute('xsi:type'));
+        self::assertSame('32', $effectiveProfile->getAttribute('length'));
+        self::assertSame('false', $effectiveProfile->getAttribute('nullable'));
+
+        $fallbackReason = $this->querySingleNode(
+            $xpath,
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/column[@name='fallback_reason']"
+        );
+        self::assertSame('varchar', $fallbackReason->getAttribute('xsi:type'));
+        self::assertSame('64', $fallbackReason->getAttribute('length'));
+        self::assertSame('true', $fallbackReason->getAttribute('nullable'));
+    }
+
+    public function testItDeclaresPrimaryKeyForExecutionHistoryTable(): void
+    {
+        $xpath = $this->createXPath();
+
+        $primaryKey = $xpath->query(
+            "/schema/table[@name='shaunmcmanus_chaosdonkey_execution_history']/constraint[@xsi:type='primary']/column[@name='history_id']"
+        );
+
+        self::assertCount(1, $primaryKey);
+    }
+
+    private function createXPath(): DOMXPath
+    {
+        $filePath = dirname(__DIR__, 3) . '/etc/db_schema.xml';
+
+        self::assertFileExists($filePath);
+
+        $document = new DOMDocument();
+        $document->load($filePath);
+
+        $xpath = new DOMXPath($document);
+        $xpath->registerNamespace('xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+
+        return $xpath;
+    }
+
+    private function querySingleNode(DOMXPath $xpath, string $expression): \DOMElement
+    {
+        $nodes = $xpath->query($expression);
+
+        self::assertCount(1, $nodes);
+        self::assertInstanceOf(\DOMElement::class, $nodes->item(0));
+
+        return $nodes->item(0);
+    }
+}

--- a/Test/Unit/Model/ConfigTest.php
+++ b/Test/Unit/Model/ConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -278,6 +279,7 @@ class ConfigTest extends TestCase
         self::assertSame('balanced', $config->getExecutionProfile());
     }
 
+    #[AllowMockObjectsWithoutExpectations]
     #[DataProvider('requiredExecutionProfileStatusMethodProvider')]
     public function testItExposesExecutionProfileMethodsRequiredByStatusCommand(
         string $methodName,

--- a/Test/Unit/Model/ExecutionHistoryStorageTest.php
+++ b/Test/Unit/Model/ExecutionHistoryStorageTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ShaunMcManus\ChaosDonkey\Model\ExecutionHistoryStorage;
+
+class ExecutionHistoryStorageTest extends TestCase
+{
+    private ResourceConnection&MockObject $resourceConnection;
+
+    private AdapterInterface&MockObject $connection;
+
+    protected function setUp(): void
+    {
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->connection = $this->createMock(AdapterInterface::class);
+    }
+
+    public function testItAppendsExecutionHistoryRowsToModuleTable(): void
+    {
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getTableName')
+            ->with('shaunmcmanus_chaosdonkey_execution_history')
+            ->willReturn('prefix_shaunmcmanus_chaosdonkey_execution_history');
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('insert')
+            ->with('prefix_shaunmcmanus_chaosdonkey_execution_history', [
+                'executed_at' => '2026-04-02 10:00:00',
+                'source' => 'cli',
+                'kick' => 20,
+                'outcome' => 'critical_success',
+                'configured_profile' => 'balanced',
+                'effective_profile' => 'balanced',
+                'fallback_reason' => null,
+            ]);
+
+        $storage = new ExecutionHistoryStorage($this->resourceConnection);
+
+        $storage->append(
+            '2026-04-02 10:00:00',
+            'cli',
+            20,
+            'critical_success',
+            'balanced',
+            'balanced',
+            null
+        );
+    }
+
+    public function testItReturnsRecentExecutionHistoryInDescendingOrder(): void
+    {
+        $expectedRows = [
+            [
+                'history_id' => 2,
+                'executed_at' => '2026-04-02 10:05:00',
+                'source' => 'cron',
+                'kick' => 80,
+                'outcome' => 'cache_flush',
+                'configured_profile' => 'chaos',
+                'effective_profile' => 'chaos',
+                'fallback_reason' => null,
+            ],
+        ];
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getTableName')
+            ->with('shaunmcmanus_chaosdonkey_execution_history')
+            ->willReturn('prefix_shaunmcmanus_chaosdonkey_execution_history');
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('fetchAll')
+            ->with(
+                self::callback(static function (string $sql): bool {
+                    return str_contains($sql, 'history_id, executed_at, source, kick, outcome, configured_profile, effective_profile, fallback_reason')
+                        && str_contains($sql, 'prefix_shaunmcmanus_chaosdonkey_execution_history')
+                        && str_contains($sql, 'ORDER BY history_id DESC')
+                        && str_contains($sql, 'LIMIT 5');
+                }),
+                []
+            )
+            ->willReturn($expectedRows);
+
+        $storage = new ExecutionHistoryStorage($this->resourceConnection);
+
+        self::assertSame($expectedRows, $storage->getRecent(5));
+    }
+}

--- a/Test/Unit/Model/KickExecutorTest.php
+++ b/Test/Unit/Model/KickExecutorTest.php
@@ -5,10 +5,12 @@ namespace ShaunMcManus\ChaosDonkey\Test\Unit\Model;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use ShaunMcManus\ChaosDonkey\Api\ChaosActionInterface;
 use ShaunMcManus\ChaosDonkey\Model\ActionPool;
 use ShaunMcManus\ChaosDonkey\Model\ChaosActionResult;
 use ShaunMcManus\ChaosDonkey\Model\Config;
+use ShaunMcManus\ChaosDonkey\Model\ExecutionHistoryStorage;
 use ShaunMcManus\ChaosDonkey\Model\KickExecutor;
 use ShaunMcManus\ChaosDonkey\Model\KickRoller;
 use ShaunMcManus\ChaosDonkey\Model\Profile\ProfiledRollSelector;
@@ -19,6 +21,7 @@ class KickExecutorTest extends TestCase
 {
     private Config&MockObject $config;
     private ActionPool&MockObject $actionPool;
+    private ExecutionHistoryStorage&MockObject $executionHistoryStorage;
     private ProfiledRollSelector $profiledRollSelector;
     private StateWriter&MockObject $stateWriter;
     private KickRoller&MockObject $kickRoller;
@@ -27,6 +30,7 @@ class KickExecutorTest extends TestCase
     {
         $this->config = $this->createMock(Config::class);
         $this->actionPool = $this->createMock(ActionPool::class);
+        $this->executionHistoryStorage = $this->createMock(ExecutionHistoryStorage::class);
         $this->profiledRollSelector = new ProfiledRollSelector();
         $this->stateWriter = $this->createMock(StateWriter::class);
         $this->kickRoller = $this->createMock(KickRoller::class);
@@ -69,10 +73,32 @@ class KickExecutorTest extends TestCase
                 return $parsed !== false && $parsed->format(DATE_ATOM) === $timestamp;
             }));
         $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
-        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with(self::isType('string'));
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with(self::callback('is_string'));
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::callback(static function (string $executedAt): bool {
+                    $parsed = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $executedAt);
 
-        $executor = new KickExecutor($this->config, $this->actionPool, $this->profiledRollSelector, $this->stateWriter, $this->kickRoller);
-        $result = $executor->execute();
+                    return $parsed !== false && $parsed->format('Y-m-d H:i:s') === $executedAt;
+                }),
+                'cli',
+                3,
+                self::callback('is_string'),
+                'balanced',
+                'balanced',
+                null
+            );
+
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+        $result = $executor->execute('cli');
 
         self::assertSame(3, $result['kick']);
         self::assertIsString($result['outcome']);
@@ -113,9 +139,27 @@ class KickExecutorTest extends TestCase
             return $kick === 3 && $kick >= 1 && $kick <= 20;
         }));
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('graphql_pipeline_stress');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cli',
+                3,
+                'graphql_pipeline_stress',
+                'balanced',
+                'balanced',
+                null
+            );
 
-        $executor = new KickExecutor($this->config, $this->actionPool, $this->profiledRollSelector, $this->stateWriter, $this->kickRoller);
-        $result = $executor->execute();
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+        $result = $executor->execute('cli');
 
         self::assertSame(3, $result['kick']);
         self::assertSame('graphql_pipeline_stress', $result['outcome']);
@@ -126,12 +170,124 @@ class KickExecutorTest extends TestCase
         ], $result['messages']);
     }
 
+    public function testItStillReturnsCliResultWhenHistoryWriteFails(): void
+    {
+        $action = $this->createMock(ChaosActionInterface::class);
+        $action->expects(self::once())
+            ->method('execute')
+            ->willReturnCallback(static function (BufferedOutput $output): ChaosActionResult {
+                $output->writeln('Cache flush started');
+
+                return new ChaosActionResult('cache_flush', 'Cache flush completed');
+            });
+
+        $this->config->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', true],
+                ['cache_flush', true],
+                ['graphql_pipeline_stress', true],
+                ['indexer_status_snapshot', true],
+                ['cache_backend_health_snapshot', true],
+                ['cron_queue_health_snapshot', true],
+            ]);
+        $this->config->expects(self::once())->method('getExecutionProfile')->willReturn('balanced');
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(3);
+        $this->actionPool->expects(self::once())->method('get')->with('cache_flush')->willReturn($action);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(3);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cli',
+                3,
+                'cache_flush',
+                'balanced',
+                'balanced',
+                null
+            )
+            ->willThrowException(new RuntimeException('history insert failed'));
+
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+
+        $result = $executor->execute('cli');
+
+        self::assertSame(3, $result['kick']);
+        self::assertSame('cache_flush', $result['outcome']);
+        self::assertSame([
+            'ChaosDonkeyKick kicks your Magento. You rolled a 3',
+            'Cache flush started',
+            'Cache flush completed',
+        ], $result['messages']);
+    }
+
+    public function testItStillReturnsCronResultWhenHistoryWriteFails(): void
+    {
+        $this->config->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturnMap([
+                ['reindex_all', true],
+                ['cache_flush', false],
+                ['graphql_pipeline_stress', false],
+                ['indexer_status_snapshot', false],
+                ['cache_backend_health_snapshot', true],
+                ['cron_queue_health_snapshot', false],
+            ]);
+        $this->config->expects(self::once())->method('getExecutionProfile')->willReturn('balanced');
+        $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(4);
+        $this->actionPool->expects(self::once())->method('get')->with('cache_backend_health_snapshot')->willReturn(null);
+
+        $this->stateWriter->expects(self::once())->method('saveLastRun');
+        $this->stateWriter->expects(self::once())->method('saveLastKick')->with(4);
+        $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_backend_health_snapshot');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cron',
+                4,
+                'cache_backend_health_snapshot',
+                'balanced',
+                'balanced',
+                null
+            )
+            ->willThrowException(new RuntimeException('history insert failed'));
+
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+
+        $result = $executor->execute('cron');
+
+        self::assertSame(4, $result['kick']);
+        self::assertSame('cache_backend_health_snapshot', $result['outcome']);
+        self::assertSame([
+            'ChaosDonkeyKick kicks your Magento. You rolled a 4',
+            'Unknown chaos outcome. The donkeys stare suspiciously.',
+        ], $result['messages']);
+    }
+
     public function testItWarnsOnceWhenAllActionsDisabledAndExecutesNonActionOutcome(): void
     {
         $this->config->expects(self::exactly(6))
             ->method('isActionEnabled')
             ->willReturn(false);
-        $this->config->expects(self::once())->method('getExecutionProfile')->willReturn('balanced');
+        $this->config->expects(self::once())->method('getExecutionProfile')->willReturn('custom_profile_that_falls_back');
         $this->kickRoller->expects(self::once())->method('rollD20')->willReturn(2);
         $this->actionPool->expects(self::once())->method('get')->with('critical_failure')->willReturn(null);
 
@@ -140,9 +296,27 @@ class KickExecutorTest extends TestCase
             return $kick === 2 && $kick >= 1 && $kick <= 20;
         }));
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('critical_failure');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cli',
+                2,
+                'critical_failure',
+                'custom_profile_that_falls_back',
+                'balanced',
+                'invalid_configured_profile'
+            );
 
-        $executor = new KickExecutor($this->config, $this->actionPool, $this->profiledRollSelector, $this->stateWriter, $this->kickRoller);
-        $result = $executor->execute();
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+        $result = $executor->execute('cli');
 
         self::assertSame(2, $result['kick']);
         self::assertSame('critical_failure', $result['outcome']);
@@ -179,9 +353,27 @@ class KickExecutorTest extends TestCase
             return $kick === 8 && $kick >= 1 && $kick <= 20;
         }));
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_flush');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cli',
+                8,
+                'cache_flush',
+                'all_gas_no_brakes',
+                'all_gas_no_brakes',
+                null
+            );
 
-        $executor = new KickExecutor($this->config, $this->actionPool, $this->profiledRollSelector, $this->stateWriter, $this->kickRoller);
-        $result = $executor->execute();
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+        $result = $executor->execute('cli');
 
         self::assertSame(8, $result['kick']);
         self::assertSame('cache_flush', $result['outcome']);
@@ -219,9 +411,27 @@ class KickExecutorTest extends TestCase
         $this->stateWriter->expects(self::once())->method('saveLastRun');
         $this->stateWriter->expects(self::once())->method('saveLastKick')->with(4);
         $this->stateWriter->expects(self::once())->method('saveLastOutcome')->with('cache_backend_health_snapshot');
+        $this->executionHistoryStorage->expects(self::once())
+            ->method('append')
+            ->with(
+                self::anything(),
+                'cron',
+                4,
+                'cache_backend_health_snapshot',
+                'balanced',
+                'balanced',
+                null
+            );
 
-        $executor = new KickExecutor($this->config, $this->actionPool, $this->profiledRollSelector, $this->stateWriter, $this->kickRoller);
-        $result = $executor->execute();
+        $executor = new KickExecutor(
+            $this->config,
+            $this->actionPool,
+            $this->profiledRollSelector,
+            $this->stateWriter,
+            $this->kickRoller,
+            $this->executionHistoryStorage
+        );
+        $result = $executor->execute('cron');
 
         self::assertSame(4, $result['kick']);
         self::assertSame('cache_backend_health_snapshot', $result['outcome']);

--- a/Test/Unit/Model/StateWriterTest.php
+++ b/Test/Unit/Model/StateWriterTest.php
@@ -53,4 +53,5 @@ class StateWriterTest extends TestCase
 
         $stateWriter->saveLastOutcome('critical_success');
     }
+
 }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="shaunmcmanus_chaosdonkey_execution_history" resource="default" engine="innodb" comment="ChaosDonkey Execution History">
+        <column xsi:type="int" name="history_id" unsigned="true" nullable="false" identity="true" comment="History ID"/>
+        <column xsi:type="datetime" name="executed_at" nullable="false" comment="Executed At"/>
+        <column xsi:type="varchar" name="source" nullable="false" length="16" comment="Execution Source"/>
+        <column xsi:type="int" name="kick" unsigned="true" nullable="false" comment="Kick Value"/>
+        <column xsi:type="varchar" name="outcome" nullable="false" length="64" comment="Outcome Code"/>
+        <column xsi:type="varchar" name="configured_profile" nullable="false" length="32" comment="Configured Profile"/>
+        <column xsi:type="varchar" name="effective_profile" nullable="false" length="32" comment="Effective Profile"/>
+        <column xsi:type="varchar" name="fallback_reason" nullable="true" length="64" comment="Fallback Reason"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="history_id"/>
+        </constraint>
+    </table>
+</schema>


### PR DESCRIPTION
## Summary
- add module-owned execution history storage and schema for recent kick runs
- record CLI and cron executions in the shared path and show bounded recent history in `chaosdonkey:status`
- make history reads and writes best-effort, then document the degraded behavior for operators

## Test Plan
- [x] composer validate --no-check-publish
- [x] vendor/bin/phpunit