### PR TITLE
Add source-aware status health

### DIFF
--- a/Console/Command/ChaosDonkeyStatus.php
+++ b/Console/Command/ChaosDonkeyStatus.php
@@ -56,9 +56,14 @@ class ChaosDonkeyStatus extends Command
         $configuredProfile = $this->config->getExecutionProfile();
         $effectiveProfile = $this->config->getEffectiveExecutionProfile();
         $fallbackReason = $this->config->getExecutionProfileFallbackReason();
+        $cronEnabled = $this->config->isCronEnabled();
         $recentHistoryUnavailable = false;
+        $latestCliExecution = null;
+        $latestCronExecution = null;
 
         try {
+            $latestCliExecution = $this->executionHistoryStorage->getLatestForSource('cli');
+            $latestCronExecution = $this->executionHistoryStorage->getLatestForSource('cron');
             $recentHistory = $this->executionHistoryStorage->getRecent(self::RECENT_HISTORY_LIMIT);
         } catch (\Throwable) {
             $recentHistoryUnavailable = true;
@@ -79,6 +84,13 @@ class ChaosDonkeyStatus extends Command
             if ($fallbackReason === 'invalid_fallback_profile') {
                 $output->writeln('Fallback mode: emergency_legacy_balanced_table');
             }
+        }
+
+        $output->writeln('Last CLI execution: ' . $this->formatLatestExecution($latestCliExecution, $recentHistoryUnavailable));
+        $output->writeln('Last cron execution: ' . $this->formatLatestExecution($latestCronExecution, $recentHistoryUnavailable));
+
+        if (!$recentHistoryUnavailable && $cronEnabled && $latestCronExecution === null) {
+            $output->writeln('Cron notice: Cron is enabled but no cron execution has been recorded yet.');
         }
 
         $output->writeln('');
@@ -106,6 +118,24 @@ class ChaosDonkeyStatus extends Command
 
     private function formatRecentHistoryRow(array $historyRow): string
     {
+        return '- ' . (string) $historyRow['executed_at'] . ' | ' . (string) $historyRow['source'] . ' | ' . $this->formatExecutionSummary($historyRow);
+    }
+
+    private function formatLatestExecution(?array $historyRow, bool $recentHistoryUnavailable): string
+    {
+        if ($recentHistoryUnavailable) {
+            return 'History unavailable.';
+        }
+
+        if ($historyRow === null) {
+            return 'Never recorded.';
+        }
+
+        return (string) $historyRow['executed_at'] . ' | ' . $this->formatExecutionSummary($historyRow);
+    }
+
+    private function formatExecutionSummary(array $historyRow): string
+    {
         $profileSummary = (string) $historyRow['configured_profile'];
 
         if ((string) $historyRow['configured_profile'] !== (string) $historyRow['effective_profile']) {
@@ -113,9 +143,7 @@ class ChaosDonkeyStatus extends Command
         }
 
         $line = sprintf(
-            '- %s | %s | kick %s | %s | profile %s',
-            (string) $historyRow['executed_at'],
-            (string) $historyRow['source'],
+            'kick %s | %s | profile %s',
             (string) $historyRow['kick'],
             (string) $historyRow['outcome'],
             $profileSummary

--- a/Model/ExecutionHistoryStorage.php
+++ b/Model/ExecutionHistoryStorage.php
@@ -53,4 +53,18 @@ class ExecutionHistoryStorage
 
         return $this->resourceConnection->getConnection()->fetchAll($sql);
     }
+
+    public function getLatestForSource(string $source): ?array
+    {
+        $tableName = $this->resourceConnection->getTableName(self::TABLE_NAME);
+        $sql = sprintf(
+            'SELECT %s FROM %s WHERE source = :source ORDER BY history_id DESC LIMIT 1',
+            self::SELECT_COLUMNS,
+            $tableName
+        );
+
+        $row = $this->resourceConnection->getConnection()->fetchRow($sql, ['source' => $source]);
+
+        return is_array($row) ? $row : null;
+    }
 }

--- a/Plans.md
+++ b/Plans.md
@@ -25,3 +25,13 @@ Purpose: Make execution history best-effort operator visibility instead of a har
 | 6.1 | Degrade gracefully when execution-history writes fail | CLI and cron executions still complete and keep `last_*` state updates when history insertion fails or the table is unavailable, proven by targeted automated tests | Phase 5 | cc:完了 |
 | 6.2 | Degrade gracefully when status history reads fail | `chaosdonkey:status` still renders the core operator snapshot and a safe history placeholder when history queries fail, proven by command tests | 6.1 | cc:完了 |
 | 6.3 | Re-document degraded-history behavior and re-verify the branch | `README.md` documents degraded history behavior and `composer validate --no-check-publish` plus `vendor/bin/phpunit` pass after the hardening changes | 6.2 | cc:完了 |
+
+## Phase 7: Source-aware execution health
+
+Purpose: Turn execution history into a clearer operator snapshot by showing the latest CLI and cron executions and surfacing a soft cron-visibility notice in `chaosdonkey:status`.
+
+| Task | 内容 | DoD | Depends | Status |
+|------|------|-----|---------|--------|
+| 7.1 | Add source-aware execution-history reads for the latest CLI and cron runs | `ExecutionHistoryStorage` exposes tested reads for the most recent `cli` and `cron` rows without regressing the existing bounded recent-history query | Phase 6 | cc:TODO |
+| 7.2 | Extend `chaosdonkey:status` with last CLI/cron execution lines and a soft cron notice | Command output shows last CLI execution, last cron execution, and a soft notice when cron is enabled but no cron history exists, proven by command tests and preserving degraded-history behavior | 7.1 | cc:TODO |
+| 7.3 | Document source-aware status health and re-verify the branch | `README.md` explains the new status-health lines and `composer validate --no-check-publish` plus `vendor/bin/phpunit` pass after the changes | 7.2 | cc:TODO |

--- a/Plans.md
+++ b/Plans.md
@@ -32,6 +32,6 @@ Purpose: Turn execution history into a clearer operator snapshot by showing the 
 
 | Task | 内容 | DoD | Depends | Status |
 |------|------|-----|---------|--------|
-| 7.1 | Add source-aware execution-history reads for the latest CLI and cron runs | `ExecutionHistoryStorage` exposes tested reads for the most recent `cli` and `cron` rows without regressing the existing bounded recent-history query | Phase 6 | cc:TODO |
-| 7.2 | Extend `chaosdonkey:status` with last CLI/cron execution lines and a soft cron notice | Command output shows last CLI execution, last cron execution, and a soft notice when cron is enabled but no cron history exists, proven by command tests and preserving degraded-history behavior | 7.1 | cc:TODO |
-| 7.3 | Document source-aware status health and re-verify the branch | `README.md` explains the new status-health lines and `composer validate --no-check-publish` plus `vendor/bin/phpunit` pass after the changes | 7.2 | cc:TODO |
+| 7.1 | Add source-aware execution-history reads for the latest CLI and cron runs | `ExecutionHistoryStorage` exposes tested reads for the most recent `cli` and `cron` rows without regressing the existing bounded recent-history query | Phase 6 | cc:完了 |
+| 7.2 | Extend `chaosdonkey:status` with last CLI/cron execution lines and a soft cron notice | Command output shows last CLI execution, last cron execution, and a soft notice when cron is enabled but no cron history exists, proven by command tests and preserving degraded-history behavior | 7.1 | cc:完了 |
+| 7.3 | Document source-aware status health and re-verify the branch | `README.md` explains the new status-health lines and `composer validate --no-check-publish` plus `vendor/bin/phpunit` pass after the changes | 7.2 | cc:完了 |

--- a/README.md
+++ b/README.md
@@ -62,10 +62,14 @@ Probe actions return their output as canonical lines in the command result paylo
 
 `chaosdonkey:kick` prints each line from the executor payload as-is, without reformatting.
 
-### Task 8 verification evidence
+### Recent verification evidence
 
 Executed in-repo in this worktree:
 
+- Composer validation:
+  - `composer validate --no-check-publish`
+- Targeted storage test:
+  - `vendor/bin/phpunit Test/Unit/Model/ExecutionHistoryStorageTest.php`
 - Targeted kick command test:
   - `vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyKickTest.php`
 - Targeted status command test:
@@ -120,9 +124,13 @@ Shows the operator-oriented status snapshot for ChaosDonkey.
 - Configured profile — reads `admin/chaos_donkey/execution_profile` from default scope.
 - Effective profile — resolved profile used at runtime after fallback handling.
 - Fallback reason (only when present) — indicates why configured and effective profiles differ.
+- Last CLI execution — shows the latest readable `source=cli` history row as `timestamp | kick <n> | <outcome> | profile <configured>` and includes `configured -> effective` plus `fallback <reason>` when applicable.
+- Last cron execution — shows the latest readable `source=cron` history row in the same summary format.
+- Empty source-aware history behavior — prints `Never recorded.` for a source when no readable history row exists for that source.
+- Soft cron visibility notice — when cron is enabled but no readable `source=cron` history row exists yet, `chaosdonkey:status` prints `Cron notice: Cron is enabled but no cron execution has been recorded yet.`
 - Recent execution history — shows up to 5 most recent recorded executions. Each line includes the execution timestamp, source (`cli` or `cron`), rolled kick, selected outcome, and profile summary. When configured and effective profiles differ, the line shows `configured -> effective`; when a fallback reason exists, it is appended to that line.
 - Empty history behavior — prints `None recorded.` until the first successful CLI or cron execution is stored and readable.
-- Degraded history-read behavior — if recent-history lookup fails, `chaosdonkey:status` still renders the core operator snapshot and toggle section, and the recent-history block prints `History unavailable.` instead of aborting the command.
+- Degraded history-read behavior — if source-aware or recent-history lookup fails, `chaosdonkey:status` still renders the core operator snapshot and toggle section, the `Last CLI execution` / `Last cron execution` lines print `History unavailable.`, and the recent-history block prints `History unavailable.` instead of aborting the command.
 - Configured Action/Probe Toggles (default scope):
   - `Reindex all: Enabled|Disabled`
   - `Cache flush: Enabled|Disabled`

--- a/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/Test/Stubs/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -17,5 +17,10 @@ interface AdapterInterface
      */
     public function fetchOne(string $sql, array $bind = []): mixed;
 
+    /**
+     * @param array<string, mixed> $bind
+     */
+    public function fetchRow(string $sql, array $bind = []): array|false;
+
     public function fetchAll(string $sql, array $bind = []): array;
 }

--- a/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
+++ b/Test/Unit/Console/Command/ChaosDonkeyStatusTest.php
@@ -53,7 +53,11 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
-        $this->expectRecentHistory([]);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(false);
+        $this->expectHistoryReads([], null, null);
 
         $tester = $this->createCommandTester();
 
@@ -68,6 +72,8 @@ class ChaosDonkeyStatusTest extends TestCase
         self::assertStringContainsString('Last outcome: reindex_all', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Last CLI execution: Never recorded.', $display);
+        self::assertStringContainsString('Last cron execution: Never recorded.', $display);
         self::assertStringContainsString('Recent execution history', $display);
         self::assertStringContainsString('None recorded.', $display);
     }
@@ -103,7 +109,11 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
-        $this->expectRecentHistory([]);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(false);
+        $this->expectHistoryReads([], null, null);
 
         $tester = $this->createCommandTester();
 
@@ -118,6 +128,8 @@ class ChaosDonkeyStatusTest extends TestCase
         self::assertStringContainsString('Last outcome: Never', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Last CLI execution: Never recorded.', $display);
+        self::assertStringContainsString('Last cron execution: Never recorded.', $display);
         self::assertStringContainsString('Recent execution history', $display);
         self::assertStringContainsString('None recorded.', $display);
 
@@ -165,7 +177,11 @@ class ChaosDonkeyStatusTest extends TestCase
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
-        $this->expectRecentHistory([]);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(false);
+        $this->expectHistoryReads([], null, null);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
@@ -188,6 +204,8 @@ Last kick: 2
 Last outcome: reindex_all
 Configured profile: balanced
 Effective profile: balanced
+Last CLI execution: Never recorded.
+Last cron execution: Never recorded.
 
 Recent execution history
 None recorded.
@@ -261,7 +279,11 @@ OUTPUT;
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
-        $this->expectRecentHistory([]);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(false);
+        $this->expectHistoryReads([], null, null);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
@@ -283,6 +305,8 @@ OUTPUT;
         self::assertStringContainsString('Last outcome: Never', $display);
         self::assertStringContainsString('Configured profile: balanced', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
+        self::assertStringContainsString('Last CLI execution: Never recorded.', $display);
+        self::assertStringContainsString('Last cron execution: Never recorded.', $display);
         self::assertStringContainsString('Recent execution history', $display);
         self::assertStringContainsString('None recorded.', $display);
         self::assertStringContainsString('Configured Action/Probe Toggles', $display);
@@ -347,10 +371,14 @@ OUTPUT;
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(true);
         $this->executionHistoryStorage
             ->expects(self::once())
-            ->method('getRecent')
-            ->with(5)
+            ->method('getLatestForSource')
+            ->with('cli')
             ->willThrowException(new RuntimeException('history query failed'));
         $this->config
             ->expects(self::exactly(6))
@@ -374,6 +402,8 @@ Last kick: 2
 Last outcome: reindex_all
 Configured profile: balanced
 Effective profile: balanced
+Last CLI execution: History unavailable.
+Last cron execution: History unavailable.
 
 Recent execution history
 History unavailable.
@@ -400,6 +430,7 @@ OUTPUT;
             ],
             $requestedActionCodes
         );
+        self::assertStringNotContainsString('Cron notice:', $display);
     }
 
     public function testItShowsAllDisabledTogglesAsDisabled(): void
@@ -433,7 +464,11 @@ OUTPUT;
             ->expects(self::once())
             ->method('getExecutionProfileFallbackReason')
             ->willReturn(null);
-        $this->expectRecentHistory([]);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(false);
+        $this->expectHistoryReads([], null, null);
         $this->config
             ->expects(self::exactly(6))
             ->method('isActionEnabled')
@@ -446,6 +481,12 @@ OUTPUT;
         $display = trim($tester->getDisplay());
 
         $expectedSection = <<<OUTPUT
+Last CLI execution: Never recorded.
+Last cron execution: Never recorded.
+
+Recent execution history
+None recorded.
+
 Configured Action/Probe Toggles
 Reindex all: Disabled
 Cache flush: Disabled
@@ -460,31 +501,31 @@ OUTPUT;
 
     public function testItDisplaysFallbackStatusWhenConfiguredAndEffectiveProfilesDiverge(): void
     {
+        $latestCron = [
+            'executed_at' => '2026-04-02 10:15:00',
+            'source' => 'cron',
+            'kick' => '7',
+            'outcome' => 'napping',
+            'configured_profile' => 'balanced',
+            'effective_profile' => 'balanced',
+            'fallback_reason' => null,
+        ];
+        $latestCli = [
+            'executed_at' => '2026-04-02 09:45:00',
+            'source' => 'cli',
+            'kick' => '3',
+            'outcome' => 'cache_flush',
+            'configured_profile' => 'chaos',
+            'effective_profile' => 'balanced',
+            'fallback_reason' => 'invalid_profile_table',
+        ];
         $config = $this->createProfileStatusConfigDouble(
             configuredProfile: 'chaos',
             effectiveProfile: 'balanced',
-            fallbackReason: 'invalid_profile_table'
+            fallbackReason: 'invalid_profile_table',
+            cronEnabled: true
         );
-        $this->expectRecentHistory([
-            [
-                'executed_at' => '2026-04-02 10:15:00',
-                'source' => 'cron',
-                'kick' => '7',
-                'outcome' => 'napping',
-                'configured_profile' => 'balanced',
-                'effective_profile' => 'balanced',
-                'fallback_reason' => null,
-            ],
-            [
-                'executed_at' => '2026-04-02 09:45:00',
-                'source' => 'cli',
-                'kick' => '3',
-                'outcome' => 'cache_flush',
-                'configured_profile' => 'chaos',
-                'effective_profile' => 'balanced',
-                'fallback_reason' => 'invalid_profile_table',
-            ],
-        ]);
+        $this->expectHistoryReads([$latestCron, $latestCli], $latestCli, $latestCron);
 
         $tester = new CommandTester(new ChaosDonkeyStatus($config, $this->executionHistoryStorage));
 
@@ -495,6 +536,8 @@ OUTPUT;
         self::assertStringContainsString('Configured profile: chaos', $display);
         self::assertStringContainsString('Effective profile: balanced', $display);
         self::assertStringContainsString('Fallback reason: invalid_profile_table', $display);
+        self::assertStringContainsString('Last CLI execution: 2026-04-02 09:45:00 | kick 3 | cache_flush | profile chaos -> balanced | fallback invalid_profile_table', $display);
+        self::assertStringContainsString('Last cron execution: 2026-04-02 10:15:00 | kick 7 | napping | profile balanced', $display);
         self::assertStringContainsString('Recent execution history', $display);
         self::assertStringContainsString('- 2026-04-02 10:15:00 | cron | kick 7 | napping | profile balanced', $display);
         self::assertStringContainsString('- 2026-04-02 09:45:00 | cli | kick 3 | cache_flush | profile chaos -> balanced | fallback invalid_profile_table', $display);
@@ -507,7 +550,7 @@ OUTPUT;
             effectiveProfile: 'balanced',
             fallbackReason: 'invalid_fallback_profile'
         );
-        $this->expectRecentHistory([]);
+        $this->expectHistoryReads([], null, null);
 
         $tester = new CommandTester(new ChaosDonkeyStatus($config, $this->executionHistoryStorage));
 
@@ -519,12 +562,85 @@ OUTPUT;
         self::assertStringContainsString('Effective profile: balanced', $display);
         self::assertStringContainsString('Fallback reason: invalid_fallback_profile', $display);
         self::assertStringContainsString('Fallback mode: emergency_legacy_balanced_table', $display);
+        self::assertStringContainsString('Last CLI execution: Never recorded.', $display);
+        self::assertStringContainsString('Last cron execution: Never recorded.', $display);
         self::assertStringContainsString('Recent execution history', $display);
         self::assertStringContainsString('None recorded.', $display);
     }
 
-    private function expectRecentHistory(array $historyRows): void
+    public function testItShowsSoftCronNoticeWhenCronIsEnabledWithoutCronHistory(): void
     {
+        $this->config = $this->createMock(Config::class);
+        $latestCli = [
+            'executed_at' => '2026-04-03 09:45:00',
+            'source' => 'cli',
+            'kick' => '11',
+            'outcome' => 'cache_flush',
+            'configured_profile' => 'balanced',
+            'effective_profile' => 'balanced',
+            'fallback_reason' => null,
+        ];
+
+        $this->config
+            ->expects(self::once())
+            ->method('isEnabled')
+            ->willReturn(true);
+        $this->config
+            ->expects(self::once())
+            ->method('getLastRun')
+            ->willReturn('2026-04-03T09:45:00+00:00');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastKick')
+            ->willReturn('11');
+        $this->config
+            ->expects(self::once())
+            ->method('getLastOutcome')
+            ->willReturn('cache_flush');
+        $this->config
+            ->expects(self::once())
+            ->method('getExecutionProfile')
+            ->willReturn('balanced');
+        $this->config
+            ->expects(self::once())
+            ->method('getEffectiveExecutionProfile')
+            ->willReturn('balanced');
+        $this->config
+            ->expects(self::once())
+            ->method('getExecutionProfileFallbackReason')
+            ->willReturn(null);
+        $this->config
+            ->expects(self::once())
+            ->method('isCronEnabled')
+            ->willReturn(true);
+        $this->expectHistoryReads([$latestCli], $latestCli, null);
+        $this->config
+            ->expects(self::exactly(6))
+            ->method('isActionEnabled')
+            ->willReturn(true);
+
+        $tester = $this->createCommandTester();
+
+        $tester->execute([]);
+
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('Last CLI execution: 2026-04-03 09:45:00 | kick 11 | cache_flush | profile balanced', $display);
+        self::assertStringContainsString('Last cron execution: Never recorded.', $display);
+        self::assertStringContainsString('Cron notice: Cron is enabled but no cron execution has been recorded yet.', $display);
+        self::assertStringContainsString('- 2026-04-03 09:45:00 | cli | kick 11 | cache_flush | profile balanced', $display);
+    }
+
+    private function expectHistoryReads(array $historyRows, ?array $latestCli, ?array $latestCron): void
+    {
+        $this->executionHistoryStorage
+            ->expects(self::exactly(2))
+            ->method('getLatestForSource')
+            ->willReturnMap([
+                ['cli', $latestCli],
+                ['cron', $latestCron],
+            ]);
+
         $this->executionHistoryStorage
             ->expects(self::once())
             ->method('getRecent')
@@ -540,21 +656,25 @@ OUTPUT;
     private function createProfileStatusConfigDouble(
         string $configuredProfile,
         string $effectiveProfile,
-        ?string $fallbackReason
+        ?string $fallbackReason,
+        bool $cronEnabled = false
     ): Config
     {
-        return new class ($configuredProfile, $effectiveProfile, $fallbackReason) extends Config {
+        return new class ($configuredProfile, $effectiveProfile, $fallbackReason, $cronEnabled) extends Config {
             private string $configuredProfile;
 
             private string $effectiveProfile;
 
             private ?string $fallbackReason;
 
-            public function __construct(string $configuredProfile, string $effectiveProfile, ?string $fallbackReason)
+            private bool $cronEnabled;
+
+            public function __construct(string $configuredProfile, string $effectiveProfile, ?string $fallbackReason, bool $cronEnabled)
             {
                 $this->configuredProfile = $configuredProfile;
                 $this->effectiveProfile = $effectiveProfile;
                 $this->fallbackReason = $fallbackReason;
+                $this->cronEnabled = $cronEnabled;
             }
 
             public function isEnabled(string $scopeType = 'store', ?string $scopeCode = null): bool
@@ -580,6 +700,11 @@ OUTPUT;
             public function isActionEnabled(string $actionCode): bool
             {
                 return true;
+            }
+
+            public function isCronEnabled(string $scopeType = 'default', ?string $scopeCode = null): bool
+            {
+                return $this->cronEnabled;
             }
 
             public function getExecutionProfile(string $scopeType = 'default', ?string $scopeCode = null): string

--- a/Test/Unit/Model/ExecutionHistoryStorageTest.php
+++ b/Test/Unit/Model/ExecutionHistoryStorageTest.php
@@ -104,4 +104,92 @@ class ExecutionHistoryStorageTest extends TestCase
 
         self::assertSame($expectedRows, $storage->getRecent(5));
     }
+
+    public function testItReturnsLatestExecutionHistoryRowForCliSource(): void
+    {
+        $expectedRow = [
+            'history_id' => 9,
+            'executed_at' => '2026-04-03 09:15:00',
+            'source' => 'cli',
+            'kick' => 18,
+            'outcome' => 'critical_success',
+            'configured_profile' => 'chaos',
+            'effective_profile' => 'chaos',
+            'fallback_reason' => null,
+        ];
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getTableName')
+            ->with('shaunmcmanus_chaosdonkey_execution_history')
+            ->willReturn('prefix_shaunmcmanus_chaosdonkey_execution_history');
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('fetchRow')
+            ->with(
+                self::callback(static function (string $sql): bool {
+                    return str_contains($sql, 'history_id, executed_at, source, kick, outcome, configured_profile, effective_profile, fallback_reason')
+                        && str_contains($sql, 'prefix_shaunmcmanus_chaosdonkey_execution_history')
+                        && str_contains($sql, 'WHERE source = :source')
+                        && str_contains($sql, 'ORDER BY history_id DESC')
+                        && str_contains($sql, 'LIMIT 1');
+                }),
+                ['source' => 'cli']
+            )
+            ->willReturn($expectedRow);
+
+        $storage = new ExecutionHistoryStorage($this->resourceConnection);
+
+        self::assertSame($expectedRow, $storage->getLatestForSource('cli'));
+    }
+
+    public function testItReturnsLatestExecutionHistoryRowForCronSource(): void
+    {
+        $expectedRow = [
+            'history_id' => 12,
+            'executed_at' => '2026-04-03 10:45:00',
+            'source' => 'cron',
+            'kick' => 7,
+            'outcome' => 'napping',
+            'configured_profile' => 'balanced',
+            'effective_profile' => 'balanced',
+            'fallback_reason' => null,
+        ];
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getTableName')
+            ->with('shaunmcmanus_chaosdonkey_execution_history')
+            ->willReturn('prefix_shaunmcmanus_chaosdonkey_execution_history');
+
+        $this->resourceConnection
+            ->expects(self::once())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+
+        $this->connection
+            ->expects(self::once())
+            ->method('fetchRow')
+            ->with(
+                self::callback(static function (string $sql): bool {
+                    return str_contains($sql, 'history_id, executed_at, source, kick, outcome, configured_profile, effective_profile, fallback_reason')
+                        && str_contains($sql, 'prefix_shaunmcmanus_chaosdonkey_execution_history')
+                        && str_contains($sql, 'WHERE source = :source')
+                        && str_contains($sql, 'ORDER BY history_id DESC')
+                        && str_contains($sql, 'LIMIT 1');
+                }),
+                ['source' => 'cron']
+            )
+            ->willReturn($expectedRow);
+
+        $storage = new ExecutionHistoryStorage($this->resourceConnection);
+
+        self::assertSame($expectedRow, $storage->getLatestForSource('cron'));
+    }
 }


### PR DESCRIPTION
## Summary
- Add source-aware execution-history reads for the latest CLI and cron runs.
- Extend `chaosdonkey:status` with last CLI/cron execution lines and a soft cron notice while preserving degraded history behavior.
- Document the new status-health output and update the Phase 7 plan markers.

## Test Plan
- [x] composer validate --no-check-publish
- [x] vendor/bin/phpunit
- [x] vendor/bin/phpunit Test/Unit/Model/ExecutionHistoryStorageTest.php
- [x] vendor/bin/phpunit Test/Unit/Console/Command/ChaosDonkeyStatusTest.php